### PR TITLE
feat: add SDK examples for Python, JavaScript, and C# (closes #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,14 @@ main
 *.http
 data.db
 .env
+
+./**/node_modules/
+# Python virtual environments
+.venv/
+
+# .NET build outputs
+bin/
+obj/
+
+# npm lockfile (let users use their own)
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ main
 data.db
 .env
 
-./**/node_modules/
+**/node_modules/
 # Python virtual environments
 .venv/
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,53 +2,58 @@
 
 Sample code for each language using the official Azure AI Search SDK against the emulator.
 
-## Prerequisites
-
-Start the emulator and set environment variables:
-
-```bash
-docker compose up -d
-
-export SEARCH_ENDPOINT=http://localhost:8080
-export SEARCH_API_KEY=<your API_KEY>
-```
-
 ## Covered Operations
 
 All samples cover the same set of operations:
 
 | Operation | Endpoint |
 |---|---|
-| Create / update index | `POST /indexes` |
+| Create / update index | `PUT /indexes/{name}` |
 | List indexes | `GET /indexes` |
 | Get index | `GET /indexes/{name}` |
 | Get index stats | `GET /indexes/{name}/stats` |
-| Upload document | `POST /indexes/{name}/docs` |
+| Upload document | `POST /indexes/{name}/docs/index` |
 | Get document by key | `GET /indexes/{name}/docs/{key}` |
 | Get document count | `GET /indexes/{name}/docs/$count` |
-| Search documents | `GET /indexes/{name}/docs?search=` |
+| Search documents | `POST /indexes/{name}/docs/search` |
 | Batch operations (upload / mergeOrUpload / delete) | `POST /indexes/{name}/docs/index` |
 | Delete index | `DELETE /indexes/{name}` |
 
 ## Python
 
+Requires Python 3.9+.
+
 ```bash
+# Start emulator
+API_KEY=dev-api-key go run main.go &
+
 cd examples/python
 pip install -r requirements.txt
-python sample.py
+SEARCH_ENDPOINT=http://localhost:8080 SEARCH_API_KEY=dev-api-key python sample.py
 ```
 
 ## JavaScript
 
+Requires Node.js 18+.
+
 ```bash
+# Start emulator
+API_KEY=dev-api-key go run main.go &
+
 cd examples/javascript
 npm install
-npm start
+SEARCH_ENDPOINT=http://localhost:8080 SEARCH_API_KEY=dev-api-key npm start
 ```
 
 ## C# (.NET 8)
 
+The `Azure.Search.Documents` C# SDK requires an HTTPS endpoint.
+Start the emulator with `TLS_PORT=8443` to enable the self-signed HTTPS listener.
+
 ```bash
+# Start emulator with TLS
+API_KEY=dev-api-key TLS_PORT=8443 go run main.go &
+
 cd examples/dotnet
-dotnet run
+SEARCH_ENDPOINT=https://localhost:8443 SEARCH_API_KEY=dev-api-key dotnet run
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,54 @@
+# Examples
+
+Sample code for each language using the official Azure AI Search SDK against the emulator.
+
+## Prerequisites
+
+Start the emulator and set environment variables:
+
+```bash
+docker compose up -d
+
+export SEARCH_ENDPOINT=http://localhost:8080
+export SEARCH_API_KEY=<your API_KEY>
+```
+
+## Covered Operations
+
+All samples cover the same set of operations:
+
+| Operation | Endpoint |
+|---|---|
+| Create / update index | `POST /indexes` |
+| List indexes | `GET /indexes` |
+| Get index | `GET /indexes/{name}` |
+| Get index stats | `GET /indexes/{name}/stats` |
+| Upload document | `POST /indexes/{name}/docs` |
+| Get document by key | `GET /indexes/{name}/docs/{key}` |
+| Get document count | `GET /indexes/{name}/docs/$count` |
+| Search documents | `GET /indexes/{name}/docs?search=` |
+| Batch operations (upload / mergeOrUpload / delete) | `POST /indexes/{name}/docs/index` |
+| Delete index | `DELETE /indexes/{name}` |
+
+## Python
+
+```bash
+cd examples/python
+pip install -r requirements.txt
+python sample.py
+```
+
+## JavaScript
+
+```bash
+cd examples/javascript
+npm install
+npm start
+```
+
+## C# (.NET 8)
+
+```bash
+cd examples/dotnet
+dotnet run
+```

--- a/examples/dotnet/Example.csproj
+++ b/examples/dotnet/Example.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Search.Documents" Version="11.7.0" />
+  </ItemGroup>
+
+</Project>

--- a/examples/dotnet/Program.cs
+++ b/examples/dotnet/Program.cs
@@ -1,0 +1,146 @@
+// Azure AI Search Emulator - C# SDK sample
+//
+// Demonstrates all emulator API endpoints using the official Azure.Search.Documents SDK.
+//
+// Environment variables:
+//   SEARCH_ENDPOINT  - Emulator base URL, e.g. http://localhost:8080
+//   SEARCH_API_KEY   - API key configured via the emulator's API_KEY env var
+
+using Azure;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Indexes;
+using Azure.Search.Documents.Indexes.Models;
+using Azure.Search.Documents.Models;
+
+var endpoint = new Uri(Environment.GetEnvironmentVariable("SEARCH_ENDPOINT") ?? "http://localhost:8080");
+var apiKey = Environment.GetEnvironmentVariable("SEARCH_API_KEY") ?? "dev-api-key";
+const string IndexName = "hotels";
+
+var credential = new AzureKeyCredential(apiKey);
+var indexClient = new SearchIndexClient(endpoint, credential);
+
+await CreateIndexAsync();
+await ListIndexesAsync();
+await GetIndexAsync();
+await UploadDocumentsAsync();
+await GetDocumentAsync();
+await GetDocumentCountAsync();
+await GetIndexStatsAsync();
+await SearchDocumentsAsync("*");
+await SearchDocumentsAsync("Tokyo");
+await BatchOperationsAsync();
+await SearchDocumentsAsync("*");
+await DeleteIndexAsync();
+
+Console.WriteLine("\nDone.");
+
+async Task CreateIndexAsync()
+{
+    var fields = new FieldBuilder().Build(typeof(Hotel));
+    var index = new SearchIndex(IndexName, fields);
+    var result = await indexClient.CreateOrUpdateIndexAsync(index);
+    Console.WriteLine($"[CreateIndex] Created: {result.Value.Name}");
+}
+
+async Task ListIndexesAsync()
+{
+    var names = new List<string>();
+    await foreach (var index in indexClient.GetIndexesAsync())
+    {
+        names.Add(index.Name);
+    }
+    Console.WriteLine($"[ListIndexes] Found {names.Count} index(es): {string.Join(", ", names)}");
+}
+
+async Task GetIndexAsync()
+{
+    var index = await indexClient.GetIndexAsync(IndexName);
+    Console.WriteLine($"[GetIndex] Name={index.Value.Name}, Fields={index.Value.Fields.Count}");
+}
+
+async Task GetIndexStatsAsync()
+{
+    var stats = await indexClient.GetIndexStatisticsAsync(IndexName);
+    Console.WriteLine($"[GetIndexStats] DocumentCount={stats.Value.DocumentCount}, StorageSize={stats.Value.StorageSize}");
+}
+
+async Task UploadDocumentsAsync()
+{
+    var client = new SearchClient(endpoint, IndexName, credential);
+    var documents = new[]
+    {
+        new Hotel { HotelId = "1", HotelName = "Grand Tokyo Hotel", Description = "A luxury hotel in the heart of Tokyo.", Category = "Luxury", Rating = 4.8 },
+        new Hotel { HotelId = "2", HotelName = "Budget Inn Osaka", Description = "An affordable stay in Osaka city center.", Category = "Budget", Rating = 3.5 },
+        new Hotel { HotelId = "3", HotelName = "Seaside Resort Okinawa", Description = "Beachfront resort with stunning ocean views.", Category = "Resort", Rating = 4.6 },
+    };
+    var result = await client.UploadDocumentsAsync(documents);
+    var succeeded = result.Value.Results.Count(r => r.Succeeded);
+    Console.WriteLine($"[UploadDocuments] Uploaded {succeeded}/{documents.Length} documents");
+}
+
+async Task GetDocumentAsync()
+{
+    var client = new SearchClient(endpoint, IndexName, credential);
+    var doc = await client.GetDocumentAsync<Hotel>("1");
+    Console.WriteLine($"[GetDocument] HotelId={doc.Value.HotelId}, HotelName={doc.Value.HotelName}");
+}
+
+async Task GetDocumentCountAsync()
+{
+    var client = new SearchClient(endpoint, IndexName, credential);
+    var count = await client.GetDocumentCountAsync();
+    Console.WriteLine($"[GetDocumentCount] Count={count.Value}");
+}
+
+async Task SearchDocumentsAsync(string query)
+{
+    var client = new SearchClient(endpoint, IndexName, credential);
+    var results = await client.SearchAsync<Hotel>(query);
+    var docs = new List<Hotel>();
+    await foreach (var result in results.Value.GetResultsAsync())
+    {
+        docs.Add(result.Document);
+    }
+    Console.WriteLine($"[SearchDocuments] query={query}, found={docs.Count}");
+    foreach (var doc in docs)
+    {
+        Console.WriteLine($"  HotelId={doc.HotelId}, HotelName={doc.HotelName}");
+    }
+}
+
+async Task BatchOperationsAsync()
+{
+    var client = new SearchClient(endpoint, IndexName, credential);
+    var batch = IndexDocumentsBatch.Create(
+        IndexDocumentsAction.Upload(new Hotel { HotelId = "4", HotelName = "Mountain Lodge Hokkaido", Rating = 4.2 }),
+        IndexDocumentsAction.MergeOrUpload(new Hotel { HotelId = "2", HotelName = "Budget Inn Osaka", Rating = 3.8 }),
+        IndexDocumentsAction.Delete(new Hotel { HotelId = "3" })
+    );
+    var result = await client.IndexDocumentsAsync(batch);
+    var succeeded = result.Value.Results.Count(r => r.Succeeded);
+    Console.WriteLine($"[BatchOperations] Processed {succeeded}/{batch.Actions.Count} actions");
+}
+
+async Task DeleteIndexAsync()
+{
+    await indexClient.DeleteIndexAsync(IndexName);
+    Console.WriteLine($"[DeleteIndex] Deleted: {IndexName}");
+}
+
+public class Hotel
+{
+    [SimpleField(IsKey = true)]
+    public string? HotelId { get; set; }
+
+    [SearchableField]
+    public string? HotelName { get; set; }
+
+    [SearchableField]
+    public string? Description { get; set; }
+
+    [SimpleField(IsFilterable = true)]
+    public string? Category { get; set; }
+
+    [SimpleField(IsFilterable = true, IsSortable = true)]
+    public double? Rating { get; set; }
+}

--- a/examples/dotnet/Program.cs
+++ b/examples/dotnet/Program.cs
@@ -2,22 +2,38 @@
 //
 // Demonstrates all emulator API endpoints using the official Azure.Search.Documents SDK.
 //
+// The Azure.Search.Documents SDK requires an HTTPS endpoint. Start the emulator with
+// TLS_PORT=8443 to enable the self-signed HTTPS listener, then point this sample at it.
+//
 // Environment variables:
-//   SEARCH_ENDPOINT  - Emulator base URL, e.g. http://localhost:8080
+//   SEARCH_ENDPOINT  - Emulator HTTPS URL, e.g. https://localhost:8443
 //   SEARCH_API_KEY   - API key configured via the emulator's API_KEY env var
 
+using System.Net.Http;
+using System.Net.Security;
 using Azure;
+using Azure.Core.Pipeline;
 using Azure.Search.Documents;
 using Azure.Search.Documents.Indexes;
 using Azure.Search.Documents.Indexes.Models;
 using Azure.Search.Documents.Models;
 
-var endpoint = new Uri(Environment.GetEnvironmentVariable("SEARCH_ENDPOINT") ?? "http://localhost:8080");
+var endpoint = new Uri(Environment.GetEnvironmentVariable("SEARCH_ENDPOINT") ?? "https://localhost:8443");
 var apiKey = Environment.GetEnvironmentVariable("SEARCH_API_KEY") ?? "dev-api-key";
 const string IndexName = "hotels";
 
+// Bypass self-signed certificate validation for the local emulator.
+var handler = new HttpClientHandler
+{
+    ServerCertificateCustomValidationCallback = (_, _, _, _) => true
+};
+var options = new SearchClientOptions
+{
+    Transport = new HttpClientTransport(handler)
+};
+
 var credential = new AzureKeyCredential(apiKey);
-var indexClient = new SearchIndexClient(endpoint, credential);
+var indexClient = new SearchIndexClient(endpoint, credential, options);
 
 await CreateIndexAsync();
 await ListIndexesAsync();
@@ -66,7 +82,7 @@ async Task GetIndexStatsAsync()
 
 async Task UploadDocumentsAsync()
 {
-    var client = new SearchClient(endpoint, IndexName, credential);
+    var client = new SearchClient(endpoint, IndexName, credential, options);
     var documents = new[]
     {
         new Hotel { HotelId = "1", HotelName = "Grand Tokyo Hotel", Description = "A luxury hotel in the heart of Tokyo.", Category = "Luxury", Rating = 4.8 },
@@ -80,21 +96,21 @@ async Task UploadDocumentsAsync()
 
 async Task GetDocumentAsync()
 {
-    var client = new SearchClient(endpoint, IndexName, credential);
+    var client = new SearchClient(endpoint, IndexName, credential, options);
     var doc = await client.GetDocumentAsync<Hotel>("1");
     Console.WriteLine($"[GetDocument] HotelId={doc.Value.HotelId}, HotelName={doc.Value.HotelName}");
 }
 
 async Task GetDocumentCountAsync()
 {
-    var client = new SearchClient(endpoint, IndexName, credential);
+    var client = new SearchClient(endpoint, IndexName, credential, options);
     var count = await client.GetDocumentCountAsync();
     Console.WriteLine($"[GetDocumentCount] Count={count.Value}");
 }
 
 async Task SearchDocumentsAsync(string query)
 {
-    var client = new SearchClient(endpoint, IndexName, credential);
+    var client = new SearchClient(endpoint, IndexName, credential, options);
     var results = await client.SearchAsync<Hotel>(query);
     var docs = new List<Hotel>();
     await foreach (var result in results.Value.GetResultsAsync())
@@ -110,7 +126,7 @@ async Task SearchDocumentsAsync(string query)
 
 async Task BatchOperationsAsync()
 {
-    var client = new SearchClient(endpoint, IndexName, credential);
+    var client = new SearchClient(endpoint, IndexName, credential, options);
     var batch = IndexDocumentsBatch.Create(
         IndexDocumentsAction.Upload(new Hotel { HotelId = "4", HotelName = "Mountain Lodge Hokkaido", Rating = 4.2 }),
         IndexDocumentsAction.MergeOrUpload(new Hotel { HotelId = "2", HotelName = "Budget Inn Osaka", Rating = 3.8 }),

--- a/examples/javascript/index.js
+++ b/examples/javascript/index.js
@@ -8,14 +8,16 @@
  *   SEARCH_API_KEY   - API key configured via the emulator's API_KEY env var
  */
 
-import { SearchClient, SearchIndexClient, AzureKeyCredential } from "@azure/search-documents";
+import { SearchClient, SearchIndexClient, AzureKeyCredential, IndexDocumentsBatch } from "@azure/search-documents";
 
 const ENDPOINT = process.env.SEARCH_ENDPOINT ?? "http://localhost:8080";
 const API_KEY = process.env.SEARCH_API_KEY ?? "dev-api-key";
 const INDEX_NAME = "hotels";
 
+// allowInsecureConnection is required for http:// (non-TLS) endpoints.
 const credential = new AzureKeyCredential(API_KEY);
-const indexClient = new SearchIndexClient(ENDPOINT, credential);
+const clientOptions = { allowInsecureConnection: true };
+const indexClient = new SearchIndexClient(ENDPOINT, credential, clientOptions);
 
 async function createIndex() {
   const index = {
@@ -53,7 +55,7 @@ async function getIndexStats() {
 }
 
 async function uploadDocuments() {
-  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential);
+  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential, clientOptions);
   const documents = [
     {
       hotelId: "1",
@@ -83,19 +85,19 @@ async function uploadDocuments() {
 }
 
 async function getDocument() {
-  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential);
+  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential, clientOptions);
   const doc = await client.getDocument("1");
   console.log(`[getDocument] hotelId=${doc.hotelId}, hotelName=${doc.hotelName}`);
 }
 
 async function getDocumentCount() {
-  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential);
+  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential, clientOptions);
   const count = await client.getDocumentsCount();
   console.log(`[getDocumentCount] Count=${count}`);
 }
 
 async function searchDocuments(query = "*") {
-  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential);
+  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential, clientOptions);
   const results = await client.search(query);
   const docs = [];
   for await (const result of results.results) {
@@ -108,15 +110,14 @@ async function searchDocuments(query = "*") {
 }
 
 async function batchOperations() {
-  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential);
-  const batch = [
-    { "@search.action": "upload", hotelId: "4", hotelName: "Mountain Lodge Hokkaido", rating: 4.2 },
-    { "@search.action": "mergeOrUpload", hotelId: "2", hotelName: "Budget Inn Osaka", rating: 3.8 },
-    { "@search.action": "delete", hotelId: "3" },
-  ];
+  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential, clientOptions);
+  const batch = new IndexDocumentsBatch();
+  batch.upload([{ hotelId: "4", hotelName: "Mountain Lodge Hokkaido", rating: 4.2 }]);
+  batch.mergeOrUpload([{ hotelId: "2", hotelName: "Budget Inn Osaka", rating: 3.8 }]);
+  batch.delete([{ hotelId: "3" }]);
   const result = await client.indexDocuments(batch);
   const succeeded = result.results.filter((r) => r.succeeded).length;
-  console.log(`[batchOperations] Processed ${succeeded}/${batch.length} actions`);
+  console.log(`[batchOperations] Processed ${succeeded}/${batch.actions.length} actions`);
 }
 
 async function deleteIndex() {

--- a/examples/javascript/index.js
+++ b/examples/javascript/index.js
@@ -1,0 +1,144 @@
+/**
+ * Azure AI Search Emulator - JavaScript SDK sample
+ *
+ * Demonstrates all emulator API endpoints using the official @azure/search-documents SDK.
+ *
+ * Environment variables:
+ *   SEARCH_ENDPOINT  - Emulator base URL, e.g. http://localhost:8080
+ *   SEARCH_API_KEY   - API key configured via the emulator's API_KEY env var
+ */
+
+import { SearchClient, SearchIndexClient, AzureKeyCredential } from "@azure/search-documents";
+
+const ENDPOINT = process.env.SEARCH_ENDPOINT ?? "http://localhost:8080";
+const API_KEY = process.env.SEARCH_API_KEY ?? "dev-api-key";
+const INDEX_NAME = "hotels";
+
+const credential = new AzureKeyCredential(API_KEY);
+const indexClient = new SearchIndexClient(ENDPOINT, credential);
+
+async function createIndex() {
+  const index = {
+    name: INDEX_NAME,
+    fields: [
+      { name: "hotelId", type: "Edm.String", key: true },
+      { name: "hotelName", type: "Edm.String", searchable: true },
+      { name: "description", type: "Edm.String", searchable: true },
+      { name: "category", type: "Edm.String", filterable: true },
+      { name: "rating", type: "Edm.Double", filterable: true, sortable: true },
+    ],
+  };
+  const result = await indexClient.createOrUpdateIndex(index);
+  console.log(`[createIndex] Created: ${result.name}`);
+}
+
+async function listIndexes() {
+  const names = [];
+  for await (const index of indexClient.listIndexes()) {
+    names.push(index.name);
+  }
+  console.log(`[listIndexes] Found ${names.length} index(es): ${names.join(", ")}`);
+}
+
+async function getIndex() {
+  const index = await indexClient.getIndex(INDEX_NAME);
+  console.log(`[getIndex] Name=${index.name}, Fields=${index.fields.length}`);
+}
+
+async function getIndexStats() {
+  const stats = await indexClient.getIndexStatistics(INDEX_NAME);
+  console.log(
+    `[getIndexStats] DocumentCount=${stats.documentCount}, StorageSize=${stats.storageSize}`
+  );
+}
+
+async function uploadDocuments() {
+  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential);
+  const documents = [
+    {
+      hotelId: "1",
+      hotelName: "Grand Tokyo Hotel",
+      description: "A luxury hotel in the heart of Tokyo.",
+      category: "Luxury",
+      rating: 4.8,
+    },
+    {
+      hotelId: "2",
+      hotelName: "Budget Inn Osaka",
+      description: "An affordable stay in Osaka city center.",
+      category: "Budget",
+      rating: 3.5,
+    },
+    {
+      hotelId: "3",
+      hotelName: "Seaside Resort Okinawa",
+      description: "Beachfront resort with stunning ocean views.",
+      category: "Resort",
+      rating: 4.6,
+    },
+  ];
+  const result = await client.uploadDocuments(documents);
+  const succeeded = result.results.filter((r) => r.succeeded).length;
+  console.log(`[uploadDocuments] Uploaded ${succeeded}/${documents.length} documents`);
+}
+
+async function getDocument() {
+  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential);
+  const doc = await client.getDocument("1");
+  console.log(`[getDocument] hotelId=${doc.hotelId}, hotelName=${doc.hotelName}`);
+}
+
+async function getDocumentCount() {
+  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential);
+  const count = await client.getDocumentsCount();
+  console.log(`[getDocumentCount] Count=${count}`);
+}
+
+async function searchDocuments(query = "*") {
+  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential);
+  const results = await client.search(query);
+  const docs = [];
+  for await (const result of results.results) {
+    docs.push(result.document);
+  }
+  console.log(`[searchDocuments] query=${JSON.stringify(query)}, found=${docs.length}`);
+  for (const doc of docs) {
+    console.log(`  hotelId=${doc.hotelId}, hotelName=${doc.hotelName}`);
+  }
+}
+
+async function batchOperations() {
+  const client = new SearchClient(ENDPOINT, INDEX_NAME, credential);
+  const batch = [
+    { "@search.action": "upload", hotelId: "4", hotelName: "Mountain Lodge Hokkaido", rating: 4.2 },
+    { "@search.action": "mergeOrUpload", hotelId: "2", hotelName: "Budget Inn Osaka", rating: 3.8 },
+    { "@search.action": "delete", hotelId: "3" },
+  ];
+  const result = await client.indexDocuments(batch);
+  const succeeded = result.results.filter((r) => r.succeeded).length;
+  console.log(`[batchOperations] Processed ${succeeded}/${batch.length} actions`);
+}
+
+async function deleteIndex() {
+  await indexClient.deleteIndex(INDEX_NAME);
+  console.log(`[deleteIndex] Deleted: ${INDEX_NAME}`);
+}
+
+async function main() {
+  console.log("=== Azure AI Search Emulator - JavaScript Sample ===\n");
+  await createIndex();
+  await listIndexes();
+  await getIndex();
+  await uploadDocuments();
+  await getDocument();
+  await getDocumentCount();
+  await getIndexStats();
+  await searchDocuments("*");
+  await searchDocuments("Tokyo");
+  await batchOperations();
+  await searchDocuments("*");
+  await deleteIndex();
+  console.log("\nDone.");
+}
+
+main().catch(console.error);

--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "azure-ai-search-emulator-sample",
+  "version": "1.0.0",
+  "description": "Azure AI Search Emulator - JavaScript SDK sample",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@azure/search-documents": "^12.1.0"
+  }
+}

--- a/examples/python/requirements.txt
+++ b/examples/python/requirements.txt
@@ -1,0 +1,1 @@
+azure-search-documents==11.6.0b9

--- a/examples/python/sample.py
+++ b/examples/python/sample.py
@@ -9,17 +9,19 @@ Environment variables:
 """
 
 import os
+import azure.search.documents.indexes._search_index_client as _idx_client_mod
 from azure.core.credentials import AzureKeyCredential
-from azure.search.documents import SearchClient
+from azure.search.documents import SearchClient, IndexDocumentsBatch
 from azure.search.documents.indexes import SearchIndexClient
 from azure.search.documents.indexes.models import (
     SearchIndex,
-    SearchField,
     SearchFieldDataType,
     SimpleField,
     SearchableField,
 )
-from azure.search.documents.models import IndexDocumentsBatch
+
+# SDK rejects http:// endpoints; patch required for the local emulator (non-TLS).
+_idx_client_mod.normalize_endpoint = lambda ep: ep.rstrip("/")
 
 ENDPOINT = os.environ.get("SEARCH_ENDPOINT", "http://localhost:8080")
 API_KEY = os.environ.get("SEARCH_API_KEY", "dev-api-key")
@@ -60,7 +62,7 @@ def get_index() -> None:
 def get_index_stats() -> None:
     stats = index_client.get_index_statistics(INDEX_NAME)
     print(
-        f"[get_index_stats] DocumentCount={stats.document_count}, StorageSize={stats.storage_size}"
+        f"[get_index_stats] DocumentCount={stats['document_count']}, StorageSize={stats['storage_size']}"
     )
 
 

--- a/examples/python/sample.py
+++ b/examples/python/sample.py
@@ -1,0 +1,156 @@
+"""
+Azure AI Search Emulator - Python SDK sample
+
+Demonstrates all emulator API endpoints using the official azure-search-documents SDK.
+
+Environment variables:
+    SEARCH_ENDPOINT  - Emulator base URL, e.g. http://localhost:8080
+    SEARCH_API_KEY   - API key configured via the emulator's API_KEY env var
+"""
+
+import os
+from azure.core.credentials import AzureKeyCredential
+from azure.search.documents import SearchClient
+from azure.search.documents.indexes import SearchIndexClient
+from azure.search.documents.indexes.models import (
+    SearchIndex,
+    SearchField,
+    SearchFieldDataType,
+    SimpleField,
+    SearchableField,
+)
+from azure.search.documents.models import IndexDocumentsBatch
+
+ENDPOINT = os.environ.get("SEARCH_ENDPOINT", "http://localhost:8080")
+API_KEY = os.environ.get("SEARCH_API_KEY", "dev-api-key")
+INDEX_NAME = "hotels"
+
+credential = AzureKeyCredential(API_KEY)
+index_client = SearchIndexClient(endpoint=ENDPOINT, credential=credential)
+
+
+def create_index() -> None:
+    fields = [
+        SimpleField(name="hotelId", type=SearchFieldDataType.String, key=True),
+        SearchableField(name="hotelName", type=SearchFieldDataType.String),
+        SearchableField(name="description", type=SearchFieldDataType.String),
+        SimpleField(name="category", type=SearchFieldDataType.String, filterable=True),
+        SimpleField(
+            name="rating",
+            type=SearchFieldDataType.Double,
+            filterable=True,
+            sortable=True,
+        ),
+    ]
+    index = SearchIndex(name=INDEX_NAME, fields=fields)
+    result = index_client.create_or_update_index(index)
+    print(f"[create_index] Created: {result.name}")
+
+
+def list_indexes() -> None:
+    indexes = list(index_client.list_indexes())
+    print(f"[list_indexes] Found {len(indexes)} index(es): {[i.name for i in indexes]}")
+
+
+def get_index() -> None:
+    index = index_client.get_index(INDEX_NAME)
+    print(f"[get_index] Name={index.name}, Fields={len(index.fields)}")
+
+
+def get_index_stats() -> None:
+    stats = index_client.get_index_statistics(INDEX_NAME)
+    print(
+        f"[get_index_stats] DocumentCount={stats.document_count}, StorageSize={stats.storage_size}"
+    )
+
+
+def upload_documents() -> None:
+    client = SearchClient(endpoint=ENDPOINT, index_name=INDEX_NAME, credential=credential)
+    documents = [
+        {
+            "hotelId": "1",
+            "hotelName": "Grand Tokyo Hotel",
+            "description": "A luxury hotel in the heart of Tokyo.",
+            "category": "Luxury",
+            "rating": 4.8,
+        },
+        {
+            "hotelId": "2",
+            "hotelName": "Budget Inn Osaka",
+            "description": "An affordable stay in Osaka city center.",
+            "category": "Budget",
+            "rating": 3.5,
+        },
+        {
+            "hotelId": "3",
+            "hotelName": "Seaside Resort Okinawa",
+            "description": "Beachfront resort with stunning ocean views.",
+            "category": "Resort",
+            "rating": 4.6,
+        },
+    ]
+    result = client.upload_documents(documents=documents)
+    succeeded = sum(1 for r in result if r.succeeded)
+    print(f"[upload_documents] Uploaded {succeeded}/{len(documents)} documents")
+
+
+def get_document() -> None:
+    client = SearchClient(endpoint=ENDPOINT, index_name=INDEX_NAME, credential=credential)
+    doc = client.get_document(key="1")
+    print(f"[get_document] hotelId={doc['hotelId']}, hotelName={doc['hotelName']}")
+
+
+def get_document_count() -> None:
+    client = SearchClient(endpoint=ENDPOINT, index_name=INDEX_NAME, credential=credential)
+    count = client.get_document_count()
+    print(f"[get_document_count] Count={count}")
+
+
+def search_documents(query: str = "*") -> None:
+    client = SearchClient(endpoint=ENDPOINT, index_name=INDEX_NAME, credential=credential)
+    results = client.search(search_text=query)
+    docs = list(results)
+    print(f"[search_documents] query={query!r}, found={len(docs)}")
+    for doc in docs:
+        print(f"  hotelId={doc['hotelId']}, hotelName={doc['hotelName']}")
+
+
+def batch_operations() -> None:
+    client = SearchClient(endpoint=ENDPOINT, index_name=INDEX_NAME, credential=credential)
+    batch = IndexDocumentsBatch()
+    batch.add_upload_actions(
+        [{"hotelId": "4", "hotelName": "Mountain Lodge Hokkaido", "rating": 4.2}]
+    )
+    batch.add_merge_or_upload_actions(
+        [{"hotelId": "2", "hotelName": "Budget Inn Osaka", "rating": 3.8}]
+    )
+    batch.add_delete_actions([{"hotelId": "3"}])
+    result = client.index_documents(batch=batch)
+    succeeded = sum(1 for r in result if r.succeeded)
+    print(f"[batch_operations] Processed {succeeded}/{len(result)} actions")
+
+
+def delete_index() -> None:
+    index_client.delete_index(INDEX_NAME)
+    print(f"[delete_index] Deleted: {INDEX_NAME}")
+
+
+def main() -> None:
+    print("=== Azure AI Search Emulator - Python Sample ===\n")
+    create_index()
+    list_indexes()
+    get_index()
+    upload_documents()
+    get_document()
+    get_document_count()
+    get_index_stats()
+    search_documents("*")
+    search_documents("Tokyo")
+    batch_operations()
+    search_documents("*")
+    delete_index()
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -93,7 +93,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		}
 		c.JSON(http.StatusOK, idx)
 	})
-	// インデックス更新API
+	// インデックス更新API（create-or-update）
 	r.PUT("/indexes/:index", func(c *gin.Context) {
 		indexName := c.Param("index")
 		body, err := io.ReadAll(c.Request.Body)
@@ -102,8 +102,8 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			return
 		}
 		var req struct {
-			Name      string      `json:"name" binding:"required"`
-			Fields    interface{} `json:"fields" binding:"required"`
+			Name       string      `json:"name" binding:"required"`
+			Fields     interface{} `json:"fields" binding:"required"`
 			Suggesters interface{} `json:"suggesters,omitempty"`
 			Analyzers  interface{} `json:"analyzers,omitempty"`
 		}
@@ -111,16 +111,16 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
 			return
 		}
-		err = app.IndexService.UpdateIndex(c.Request.Context(), indexName, io.NopCloser(bytes.NewReader(body)))
+		created, err := app.IndexService.CreateOrUpdateIndex(c.Request.Context(), indexName, io.NopCloser(bytes.NewReader(body)))
 		if err != nil {
-			if err.Error() == "index not found" {
-				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
-			} else {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
-		c.Data(http.StatusOK, "application/json", body)
+		if created {
+			c.Data(http.StatusCreated, "application/json", body)
+		} else {
+			c.Data(http.StatusOK, "application/json", body)
+		}
 	})
 	// インデックス削除API
 	r.DELETE("/indexes/:index", func(c *gin.Context) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -288,11 +288,11 @@ func TestUpdateIndex_Success(t *testing.T) {
 	}
 }
 
-func TestUpdateIndex_NotFound(t *testing.T) {
+func TestUpdateIndex_CreatesWhenNotFound(t *testing.T) {
 	r := setupRouter(t)
 	rec := doRequest(t, r, http.MethodPut, "/indexes/missing", apiTestSchema)
-	if rec.Code != http.StatusNotFound {
-		t.Errorf("status = %d, want 404", rec.Code)
+	if rec.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201 (PUT creates when index absent)", rec.Code)
 	}
 }
 

--- a/internal/api/odata_rewriter.go
+++ b/internal/api/odata_rewriter.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+var (
+	indexODataRe = regexp.MustCompile(`/indexes\('([^']+)'\)`)
+	docODataRe   = regexp.MustCompile(`/docs\('([^']+)'\)`)
+)
+
+func rewriteODataPath(path string) string {
+	path = indexODataRe.ReplaceAllString(path, "/indexes/$1")
+	path = docODataRe.ReplaceAllString(path, "/docs/$1")
+	path = strings.ReplaceAll(path, "/search.stats", "/stats")
+	path = strings.ReplaceAll(path, "/docs/search.index", "/docs/index")
+	path = strings.ReplaceAll(path, "/docs/search.post.search", "/docs/search")
+	return path
+}
+
+// ODataPathRewriter wraps an http.Handler and translates Azure SDK OData-style
+// paths to the emulator's REST-style paths before routing.
+//
+// Azure SDKs generate paths like /indexes('name') and /docs/search.post.search,
+// while the emulator routes use /indexes/name and /docs/search.
+func ODataPathRewriter(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.URL.Path = rewriteODataPath(r.URL.Path)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/api/tls.go
+++ b/internal/api/tls.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"time"
+)
+
+// GenerateSelfSignedCert creates an in-memory self-signed TLS certificate for localhost.
+// Intended for local development only — not for production.
+func GenerateSelfSignedCert() (tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback},
+		DNSNames:     []string{"localhost"},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+	return tls.X509KeyPair(certPEM, keyPEM)
+}

--- a/internal/application/index_service.go
+++ b/internal/application/index_service.go
@@ -68,8 +68,7 @@ func (s *IndexService) ListIndexes(ctx context.Context, selectFields string) ([]
 		if err := json.Unmarshal([]byte(idx.Schema), &schema); err != nil {
 			continue // スキーマ不正はスキップ
 		}
-		if selectFields != "" {
-			// selectFieldsはカンマ区切り
+		if selectFields != "" && selectFields != "*" {
 			fields := map[string]struct{}{}
 			for _, f := range strings.Split(selectFields, ",") {
 				fields[strings.TrimSpace(f)] = struct{}{}
@@ -101,6 +100,39 @@ func (s *IndexService) GetIndex(ctx context.Context, name string) (map[string]in
 		return nil, fmt.Errorf("schema parse error")
 	}
 	return schema, nil
+}
+
+// CreateOrUpdateIndex upserts an index: creates it if absent, updates it if present.
+// Returns true if the index was newly created, false if it was updated.
+func (s *IndexService) CreateOrUpdateIndex(ctx context.Context, name string, body io.ReadCloser) (bool, error) {
+	defer body.Close()
+	schemaBytes, err := io.ReadAll(body)
+	if err != nil {
+		return false, fmt.Errorf("failed to read body: %w", err)
+	}
+	var tmp struct {
+		Fields []interface{} `json:"fields"`
+	}
+	if err := json.Unmarshal(schemaBytes, &tmp); err != nil {
+		return false, fmt.Errorf("invalid schema json: %w", err)
+	}
+	if len(tmp.Fields) == 0 {
+		return false, fmt.Errorf("fields required in schema")
+	}
+
+	exists, err := s.Repo.Exists(name)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		idx, err := s.Repo.FindByName(name)
+		if err != nil {
+			return false, err
+		}
+		idx.Schema = string(schemaBytes)
+		return false, s.Repo.Update(idx)
+	}
+	return true, s.Repo.Create(&domain.Index{Name: name, Schema: string(schemaBytes)})
 }
 
 func (s *IndexService) UpdateIndex(ctx context.Context, name string, body io.ReadCloser) error {

--- a/main.go
+++ b/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"crypto/tls"
 	"database/sql"
 	"log"
+	"net/http"
 	"os"
 
 	"github.com/gin-gonic/gin"
@@ -71,7 +73,29 @@ func main() {
 	if port == "" {
 		port = "8080"
 	}
-	if err := r.Run(":" + port); err != nil {
+	handler := api.ODataPathRewriter(r)
+
+	// Start optional TLS listener for SDKs that require HTTPS (e.g. Azure.Search.Documents for C#).
+	// Uses a self-signed certificate generated at startup — for local development only.
+	if tlsPort := os.Getenv("TLS_PORT"); tlsPort != "" {
+		cert, err := api.GenerateSelfSignedCert()
+		if err != nil {
+			log.Fatal("failed to generate TLS cert: ", err)
+		}
+		tlsServer := &http.Server{
+			Addr:      ":" + tlsPort,
+			Handler:   handler,
+			TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}},
+		}
+		go func() {
+			log.Printf("TLS server listening on :%s (self-signed cert)\n", tlsPort)
+			if err := tlsServer.ListenAndServeTLS("", ""); err != nil {
+				log.Fatal(err)
+			}
+		}()
+	}
+
+	if err := http.ListenAndServe(":"+port, handler); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary

- `examples/python/` — `azure-search-documents` SDK を使った Python サンプル
- `examples/javascript/` — `@azure/search-documents` SDK を使った JavaScript サンプル
- `examples/dotnet/` — `Azure.Search.Documents` SDK を使った C# (.NET 8) サンプル
- `examples/README.md` — 起動手順と対象 API 一覧

## Emulator Changes (needed for SDK compatibility)

| 変更 | 理由 |
|---|---|
| `ODataPathRewriter` ミドルウェア追加 | Azure SDK は `/indexes('name')` や `/docs/search.post.search` 等 OData スタイルのパスを生成するため |
| `TLS_PORT` による HTTPS リスナー追加 | C# SDK (`Azure.Search.Documents`) が HTTPS エンドポイントを必須とするため |
| `PUT /indexes/:index` を upsert に変更 | Azure API 仕様に合わせ (create-or-update) |
| `$select=*` を「全フィールド返却」として処理 | C# SDK が `GET /indexes?$select=*` を送るため |

## Covered Operations

すべての言語で以下のエンドポイントをカバーしています：

| Operation | Endpoint |
|---|---|
| Create / update index | `PUT /indexes/{name}` |
| List indexes | `GET /indexes` |
| Get index | `GET /indexes/{name}` |
| Get index stats | `GET /indexes/{name}/stats` |
| Upload document | `POST /indexes/{name}/docs/index` |
| Get document by key | `GET /indexes/{name}/docs/{key}` |
| Get document count | `GET /indexes/{name}/docs/$count` |
| Search documents | `POST /indexes/{name}/docs/search` |
| Batch operations (upload / mergeOrUpload / delete) | `POST /indexes/{name}/docs/index` |
| Delete index | `DELETE /indexes/{name}` |

## Test plan

- [ ] `API_KEY=dev-api-key go run main.go` でエミュレータを起動
- [ ] `cd examples/python && pip install -r requirements.txt && SEARCH_ENDPOINT=http://localhost:8080 SEARCH_API_KEY=dev-api-key python sample.py` — 全操作が "Done." まで完了する
- [ ] `cd examples/javascript && npm install && SEARCH_ENDPOINT=http://localhost:8080 SEARCH_API_KEY=dev-api-key npm start` — 全操作が "Done." まで完了する
- [ ] `API_KEY=dev-api-key TLS_PORT=8443 go run main.go` で TLS 付きエミュレータを起動
- [ ] `cd examples/dotnet && SEARCH_ENDPOINT=https://localhost:8443 SEARCH_API_KEY=dev-api-key dotnet run` — 全操作が "Done." まで完了する
- [ ] `go test ./...` — 全テスト通過

Closes #3