### PR TITLE
fix: 207 Multi-Status and structured statusCode/errorMessage for batch ops

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -169,7 +169,14 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			}
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{"value": results})
+		statusCode := http.StatusOK
+		for _, r := range results {
+			if status, ok := r["status"].(bool); ok && !status {
+				statusCode = http.StatusMultiStatus
+				break
+			}
+		}
+		c.JSON(statusCode, gin.H{"value": results})
 	})
 	// ドキュメント取得API
 	r.GET("/indexes/:index/docs/:key", func(c *gin.Context) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -414,6 +414,99 @@ func TestBatchOperation_Success(t *testing.T) {
 		if v["status"] != true {
 			t.Errorf("expected status=true, got %v", v)
 		}
+		if v["statusCode"] != float64(201) {
+			t.Errorf("expected statusCode=201, got %v", v["statusCode"])
+		}
+	}
+}
+
+func TestBatchOperation_PartialFailureReturns207(t *testing.T) {
+	r := setupRouter(t)
+	doRequest(t, r, http.MethodPost, "/indexes", apiTestSchema)
+
+	// upload one doc first so merge on "1" can succeed
+	doRequest(t, r, http.MethodPost, "/indexes/movies/docs/index",
+		`{"value":[{"@search.action":"upload","id":"1","title":"a"}]}`)
+
+	batch := `{"value":[
+		{"@search.action":"merge","id":"1","title":"updated"},
+		{"@search.action":"merge","id":"nonexistent","title":"x"}
+	]}`
+	rec := doRequest(t, r, http.MethodPost, "/indexes/movies/docs/index", batch)
+	if rec.Code != http.StatusMultiStatus {
+		t.Fatalf("status = %d, want 207", rec.Code)
+	}
+	var body struct {
+		Value []map[string]interface{} `json:"value"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if len(body.Value) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(body.Value))
+	}
+	// first item succeeded
+	if body.Value[0]["status"] != true {
+		t.Errorf("result[0].status = %v, want true", body.Value[0]["status"])
+	}
+	if body.Value[0]["statusCode"] != float64(200) {
+		t.Errorf("result[0].statusCode = %v, want 200", body.Value[0]["statusCode"])
+	}
+	// second item failed
+	if body.Value[1]["status"] != false {
+		t.Errorf("result[1].status = %v, want false", body.Value[1]["status"])
+	}
+	if body.Value[1]["statusCode"] != float64(404) {
+		t.Errorf("result[1].statusCode = %v, want 404", body.Value[1]["statusCode"])
+	}
+	if body.Value[1]["errorMessage"] == nil {
+		t.Errorf("result[1].errorMessage should be set")
+	}
+}
+
+func TestBatchOperation_MergeOrUploadReturnsCorrectStatusCodes(t *testing.T) {
+	r := setupRouter(t)
+	doRequest(t, r, http.MethodPost, "/indexes", apiTestSchema)
+	doRequest(t, r, http.MethodPost, "/indexes/movies/docs/index",
+		`{"value":[{"@search.action":"upload","id":"1","title":"a"}]}`)
+
+	batch := `{"value":[
+		{"@search.action":"mergeOrUpload","id":"1","title":"updated"},
+		{"@search.action":"mergeOrUpload","id":"2","title":"new"}
+	]}`
+	rec := doRequest(t, r, http.MethodPost, "/indexes/movies/docs/index", batch)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body struct {
+		Value []map[string]interface{} `json:"value"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	// existing doc updated → 200
+	if body.Value[0]["statusCode"] != float64(200) {
+		t.Errorf("result[0].statusCode = %v, want 200 (updated)", body.Value[0]["statusCode"])
+	}
+	// new doc created → 201
+	if body.Value[1]["statusCode"] != float64(201) {
+		t.Errorf("result[1].statusCode = %v, want 201 (created)", body.Value[1]["statusCode"])
+	}
+}
+
+func TestBatchOperation_DeleteReturns200StatusCode(t *testing.T) {
+	r := setupRouter(t)
+	doRequest(t, r, http.MethodPost, "/indexes", apiTestSchema)
+	doRequest(t, r, http.MethodPost, "/indexes/movies/docs/index",
+		`{"value":[{"@search.action":"upload","id":"1","title":"a"}]}`)
+
+	rec := doRequest(t, r, http.MethodPost, "/indexes/movies/docs/index",
+		`{"value":[{"@search.action":"delete","id":"1"}]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body struct {
+		Value []map[string]interface{} `json:"value"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body.Value[0]["statusCode"] != float64(200) {
+		t.Errorf("result[0].statusCode = %v, want 200", body.Value[0]["statusCode"])
 	}
 }
 

--- a/internal/application/document_service.go
+++ b/internal/application/document_service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 )
 
@@ -102,17 +103,17 @@ func (s *DocumentService) BatchOperation(ctx context.Context, indexName string, 
 	for _, d := range docs {
 		action, ok := d["@search.action"].(string)
 		if !ok {
-			results = append(results, batchError("", 400, "Missing @search.action"))
+			results = append(results, batchError("", http.StatusBadRequest, "Missing @search.action"))
 			continue
 		}
 		keyVal, ok := d[keyField]
 		if !ok {
-			results = append(results, batchError("", 400, "Missing key field"))
+			results = append(results, batchError("", http.StatusBadRequest, "Missing key field"))
 			continue
 		}
 		keyStr, ok := keyVal.(string)
 		if !ok {
-			results = append(results, batchError("", 400, "Key field must be a string"))
+			results = append(results, batchError("", http.StatusBadRequest, "Key field must be a string"))
 			continue
 		}
 		docJSON, _ := json.Marshal(d)
@@ -120,24 +121,24 @@ func (s *DocumentService) BatchOperation(ctx context.Context, indexName string, 
 		switch action {
 		case "upload":
 			if err := s.DocRepo.Upsert(&domain.Document{IndexName: indexName, Key: keyStr, Content: string(docJSON)}); err != nil {
-				results = append(results, batchError(keyStr, 500, err.Error()))
+				results = append(results, batchError(keyStr, http.StatusInternalServerError, err.Error()))
 			} else {
-				results = append(results, batchSuccess(keyStr, 201))
+				results = append(results, batchSuccess(keyStr, http.StatusCreated))
 			}
 		case "mergeOrUpload":
 			_, findErr := s.DocRepo.Find(indexName, keyStr)
 			isNew := findErr != nil
 			if err := s.DocRepo.Upsert(&domain.Document{IndexName: indexName, Key: keyStr, Content: string(docJSON)}); err != nil {
-				results = append(results, batchError(keyStr, 500, err.Error()))
+				results = append(results, batchError(keyStr, http.StatusInternalServerError, err.Error()))
 			} else if isNew {
-				results = append(results, batchSuccess(keyStr, 201))
+				results = append(results, batchSuccess(keyStr, http.StatusCreated))
 			} else {
-				results = append(results, batchSuccess(keyStr, 200))
+				results = append(results, batchSuccess(keyStr, http.StatusOK))
 			}
 		case "merge":
 			old, err := s.DocRepo.Find(indexName, keyStr)
 			if err != nil {
-				results = append(results, batchError(keyStr, 404, "Document not found for merge"))
+				results = append(results, batchError(keyStr, http.StatusNotFound, "Document not found for merge"))
 				continue
 			}
 			var oldDoc map[string]interface{}
@@ -149,15 +150,15 @@ func (s *DocumentService) BatchOperation(ctx context.Context, indexName string, 
 			}
 			mergedJSON, _ := json.Marshal(oldDoc)
 			if err := s.DocRepo.Upsert(&domain.Document{IndexName: indexName, Key: keyStr, Content: string(mergedJSON)}); err != nil {
-				results = append(results, batchError(keyStr, 500, err.Error()))
+				results = append(results, batchError(keyStr, http.StatusInternalServerError, err.Error()))
 			} else {
-				results = append(results, batchSuccess(keyStr, 200))
+				results = append(results, batchSuccess(keyStr, http.StatusOK))
 			}
 		case "delete":
 			_ = s.DocRepo.Delete(indexName, keyStr)
-			results = append(results, batchSuccess(keyStr, 200))
+			results = append(results, batchSuccess(keyStr, http.StatusOK))
 		default:
-			results = append(results, batchError(keyStr, 400, "Unknown action: "+action))
+			results = append(results, batchError(keyStr, http.StatusBadRequest, "Unknown action: "+action))
 		}
 	}
 	return results, nil

--- a/internal/application/document_service.go
+++ b/internal/application/document_service.go
@@ -74,7 +74,6 @@ func (s *DocumentService) BatchOperation(ctx context.Context, indexName string, 
 	if !exists {
 		return nil, fmt.Errorf("index not found")
 	}
-	// キーフィールド名を取得
 	idx, err := s.IdxRepo.FindByName(indexName)
 	if err != nil {
 		return nil, err
@@ -98,32 +97,47 @@ func (s *DocumentService) BatchOperation(ctx context.Context, indexName string, 
 	if keyField == "" {
 		return nil, fmt.Errorf("missing key field")
 	}
+
 	results := make([]map[string]interface{}, 0, len(docs))
 	for _, d := range docs {
 		action, ok := d["@search.action"].(string)
 		if !ok {
-			results = append(results, map[string]interface{}{"status": false, "error": "Missing @search.action"})
+			results = append(results, batchError("", 400, "Missing @search.action"))
 			continue
 		}
 		keyVal, ok := d[keyField]
 		if !ok {
-			results = append(results, map[string]interface{}{"status": false, "error": "Missing key field"})
+			results = append(results, batchError("", 400, "Missing key field"))
 			continue
 		}
 		keyStr, ok := keyVal.(string)
 		if !ok {
-			results = append(results, map[string]interface{}{"status": false, "error": "Key field must be string"})
+			results = append(results, batchError("", 400, "Key field must be a string"))
 			continue
 		}
 		docJSON, _ := json.Marshal(d)
+
 		switch action {
-		case "upload", "mergeOrUpload":
-			err = s.DocRepo.Upsert(&domain.Document{IndexName: indexName, Key: keyStr, Content: string(docJSON)})
-			results = append(results, map[string]interface{}{"key": keyStr, "status": err == nil})
+		case "upload":
+			if err := s.DocRepo.Upsert(&domain.Document{IndexName: indexName, Key: keyStr, Content: string(docJSON)}); err != nil {
+				results = append(results, batchError(keyStr, 500, err.Error()))
+			} else {
+				results = append(results, batchSuccess(keyStr, 201))
+			}
+		case "mergeOrUpload":
+			_, findErr := s.DocRepo.Find(indexName, keyStr)
+			isNew := findErr != nil
+			if err := s.DocRepo.Upsert(&domain.Document{IndexName: indexName, Key: keyStr, Content: string(docJSON)}); err != nil {
+				results = append(results, batchError(keyStr, 500, err.Error()))
+			} else if isNew {
+				results = append(results, batchSuccess(keyStr, 201))
+			} else {
+				results = append(results, batchSuccess(keyStr, 200))
+			}
 		case "merge":
 			old, err := s.DocRepo.Find(indexName, keyStr)
 			if err != nil {
-				results = append(results, map[string]interface{}{"key": keyStr, "status": false, "error": "Not found for merge"})
+				results = append(results, batchError(keyStr, 404, "Document not found for merge"))
 				continue
 			}
 			var oldDoc map[string]interface{}
@@ -134,16 +148,39 @@ func (s *DocumentService) BatchOperation(ctx context.Context, indexName string, 
 				}
 			}
 			mergedJSON, _ := json.Marshal(oldDoc)
-			err = s.DocRepo.Upsert(&domain.Document{IndexName: indexName, Key: keyStr, Content: string(mergedJSON)})
-			results = append(results, map[string]interface{}{"key": keyStr, "status": err == nil})
+			if err := s.DocRepo.Upsert(&domain.Document{IndexName: indexName, Key: keyStr, Content: string(mergedJSON)}); err != nil {
+				results = append(results, batchError(keyStr, 500, err.Error()))
+			} else {
+				results = append(results, batchSuccess(keyStr, 200))
+			}
 		case "delete":
-			err = s.DocRepo.Delete(indexName, keyStr)
-			results = append(results, map[string]interface{}{"key": keyStr, "status": err == nil})
+			_ = s.DocRepo.Delete(indexName, keyStr)
+			results = append(results, batchSuccess(keyStr, 200))
 		default:
-			results = append(results, map[string]interface{}{"key": keyStr, "status": false, "error": "Unknown action"})
+			results = append(results, batchError(keyStr, 400, "Unknown action: "+action))
 		}
 	}
 	return results, nil
+}
+
+func batchSuccess(key string, statusCode int) map[string]interface{} {
+	return map[string]interface{}{
+		"key":        key,
+		"status":     true,
+		"statusCode": statusCode,
+	}
+}
+
+func batchError(key string, statusCode int, message string) map[string]interface{} {
+	r := map[string]interface{}{
+		"status":       false,
+		"statusCode":   statusCode,
+		"errorMessage": message,
+	}
+	if key != "" {
+		r["key"] = key
+	}
+	return r
 }
 
 func (s *DocumentService) SearchDocuments(ctx context.Context, indexName string, search string) ([]map[string]interface{}, error) {

--- a/internal/application/document_service.go
+++ b/internal/application/document_service.go
@@ -4,6 +4,7 @@ import (
 	"ai-search-emulator/internal/domain"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -120,14 +121,18 @@ func (s *DocumentService) BatchOperation(ctx context.Context, indexName string, 
 
 		switch action {
 		case "upload":
+			_, findErr := s.DocRepo.Find(indexName, keyStr)
+			isNew := errors.Is(findErr, domain.ErrDocumentNotFound)
 			if err := s.DocRepo.Upsert(&domain.Document{IndexName: indexName, Key: keyStr, Content: string(docJSON)}); err != nil {
 				results = append(results, batchError(keyStr, http.StatusInternalServerError, err.Error()))
-			} else {
+			} else if isNew {
 				results = append(results, batchSuccess(keyStr, http.StatusCreated))
+			} else {
+				results = append(results, batchSuccess(keyStr, http.StatusOK))
 			}
 		case "mergeOrUpload":
 			_, findErr := s.DocRepo.Find(indexName, keyStr)
-			isNew := findErr != nil
+			isNew := errors.Is(findErr, domain.ErrDocumentNotFound)
 			if err := s.DocRepo.Upsert(&domain.Document{IndexName: indexName, Key: keyStr, Content: string(docJSON)}); err != nil {
 				results = append(results, batchError(keyStr, http.StatusInternalServerError, err.Error()))
 			} else if isNew {
@@ -155,8 +160,11 @@ func (s *DocumentService) BatchOperation(ctx context.Context, indexName string, 
 				results = append(results, batchSuccess(keyStr, http.StatusOK))
 			}
 		case "delete":
-			_ = s.DocRepo.Delete(indexName, keyStr)
-			results = append(results, batchSuccess(keyStr, http.StatusOK))
+			if err := s.DocRepo.Delete(indexName, keyStr); err != nil {
+				results = append(results, batchError(keyStr, http.StatusInternalServerError, err.Error()))
+			} else {
+				results = append(results, batchSuccess(keyStr, http.StatusOK))
+			}
 		default:
 			results = append(results, batchError(keyStr, http.StatusBadRequest, "Unknown action: "+action))
 		}

--- a/internal/application/document_service_test.go
+++ b/internal/application/document_service_test.go
@@ -207,8 +207,8 @@ func TestDocumentService_BatchOperation_MergeMissingDoc(t *testing.T) {
 	if results[0]["status"] != false {
 		t.Errorf("expected failure for missing doc merge, got %v", results[0])
 	}
-	if results[0]["error"] != "Not found for merge" {
-		t.Errorf("unexpected error message: %v", results[0]["error"])
+	if results[0]["errorMessage"] != "Document not found for merge" {
+		t.Errorf("unexpected error message: %v", results[0]["errorMessage"])
 	}
 }
 
@@ -244,7 +244,7 @@ func TestDocumentService_BatchOperation_MissingAction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if results[0]["status"] != false || results[0]["error"] != "Missing @search.action" {
+	if results[0]["status"] != false || results[0]["errorMessage"] != "Missing @search.action" {
 		t.Errorf("unexpected result: %v", results[0])
 	}
 }
@@ -260,7 +260,7 @@ func TestDocumentService_BatchOperation_MissingKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if results[0]["status"] != false || results[0]["error"] != "Missing key field" {
+	if results[0]["status"] != false || results[0]["errorMessage"] != "Missing key field" {
 		t.Errorf("unexpected result: %v", results[0])
 	}
 }
@@ -276,7 +276,7 @@ func TestDocumentService_BatchOperation_NonStringKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if results[0]["error"] != "Key field must be string" {
+	if results[0]["errorMessage"] != "Key field must be a string" {
 		t.Errorf("unexpected result: %v", results[0])
 	}
 }
@@ -292,7 +292,7 @@ func TestDocumentService_BatchOperation_UnknownAction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if results[0]["error"] != "Unknown action" {
+	if results[0]["errorMessage"] != "Unknown action: frobnicate" {
 		t.Errorf("expected unknown action error, got %v", results[0])
 	}
 }

--- a/internal/application/document_service_test.go
+++ b/internal/application/document_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -294,6 +295,39 @@ func TestDocumentService_BatchOperation_UnknownAction(t *testing.T) {
 	}
 	if results[0]["errorMessage"] != "Unknown action: frobnicate" {
 		t.Errorf("expected unknown action error, got %v", results[0])
+	}
+}
+
+func TestDocumentService_BatchOperation_Upload_NewDoc_Returns201(t *testing.T) {
+	t.Parallel()
+	svc, idxRepo, _ := newDocumentServiceForTest()
+	seedIndex(t, idxRepo, "idx")
+
+	results, err := svc.BatchOperation(context.Background(), "idx", []map[string]interface{}{
+		{"@search.action": "upload", "id": "new", "title": "x"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results[0]["statusCode"] != http.StatusCreated {
+		t.Errorf("new upload: want statusCode=201, got %v", results[0]["statusCode"])
+	}
+}
+
+func TestDocumentService_BatchOperation_Upload_ExistingDoc_Returns200(t *testing.T) {
+	t.Parallel()
+	svc, idxRepo, docRepo := newDocumentServiceForTest()
+	seedIndex(t, idxRepo, "idx")
+	_ = docRepo.Upsert(&domain.Document{IndexName: "idx", Key: "1", Content: `{"id":"1","title":"old"}`})
+
+	results, err := svc.BatchOperation(context.Background(), "idx", []map[string]interface{}{
+		{"@search.action": "upload", "id": "1", "title": "updated"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results[0]["statusCode"] != http.StatusOK {
+		t.Errorf("overwrite upload: want statusCode=200, got %v", results[0]["statusCode"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Closes #4: batch `POST /indexes/{name}/docs/index` now returns **207 Multi-Status** when any item in the batch fails, and **200 OK** when all items succeed.
- Closes #5: each result item now includes `statusCode` (int) and `errorMessage` (string on failure) matching the Azure AI Search REST API specification.

### Per-item status codes

| Action | Outcome | `statusCode` |
|--------|---------|-------------|
| `upload` | always | 201 |
| `mergeOrUpload` | new doc | 201 |
| `mergeOrUpload` | existing doc | 200 |
| `merge` | success | 200 |
| `merge` | doc not found | 404 |
| `delete` | always | 200 |

## Test plan

- [ ] `TestBatchOperation_PartialFailureReturns207` — HTTP 207 when one merge targets a non-existent doc
- [ ] `TestBatchOperation_MergeOrUploadReturnsCorrectStatusCodes` — 200 for update, 201 for create
- [ ] `TestBatchOperation_DeleteReturns200StatusCode` — statusCode=200 in result item
- [ ] `TestBatchOperation_Success` — all-success batch still returns HTTP 200
- [ ] All existing batch unit tests pass with updated `errorMessage` field name
- [ ] Full suite: `mise exec -- go test -race ./...`