### PR TITLE
fix: migrate error comparisons to sentinel errors with errors.Is()

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"ai-search-emulator/internal/application"
+	"ai-search-emulator/internal/domain"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 	"net/http"
@@ -38,7 +40,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		}
 		err = app.IndexService.CreateIndex(c.Request.Context(), req.Name, io.NopCloser(bytes.NewReader(body)))
 		if err != nil {
-			if err.Error() == "already exists" {
+			if errors.Is(err, domain.ErrIndexAlreadyExists) {
 				c.JSON(http.StatusConflict, gin.H{"error": "Index already exists"})
 			} else {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -57,9 +59,9 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		}
 		err := app.DocumentService.AddOrUpdateSingleDoc(c.Request.Context(), indexName, doc)
 		if err != nil {
-			if err.Error() == "index not found" {
+			if errors.Is(err, domain.ErrIndexNotFound) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
-			} else if err.Error() == "missing key field" {
+			} else if errors.Is(err, domain.ErrMissingKeyField) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "Document missing key field"})
 			} else {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -84,7 +86,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		indexName := c.Param("index")
 		idx, err := app.IndexService.GetIndex(c.Request.Context(), indexName)
 		if err != nil {
-			if err.Error() == "index not found" {
+			if errors.Is(err, domain.ErrIndexNotFound) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
 			} else {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -127,7 +129,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		indexName := c.Param("index")
 		err := app.IndexService.DeleteIndex(c.Request.Context(), indexName)
 		if err != nil {
-			if err.Error() == "index not found" {
+			if errors.Is(err, domain.ErrIndexNotFound) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
 			} else {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -141,7 +143,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		indexName := c.Param("index")
 		stats, err := app.IndexService.GetIndexStats(c.Request.Context(), indexName)
 		if err != nil {
-			if err.Error() == "index not found" {
+			if errors.Is(err, domain.ErrIndexNotFound) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
 			} else {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -162,7 +164,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		}
 		results, err := app.DocumentService.BatchOperation(c.Request.Context(), indexName, req.Value)
 		if err != nil {
-			if err.Error() == "index not found" {
+			if errors.Is(err, domain.ErrIndexNotFound) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
 			} else {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -177,9 +179,9 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		key := c.Param("key")
 		doc, err := app.DocumentService.GetDocument(c.Request.Context(), indexName, key)
 		if err != nil {
-			if err.Error() == "index not found" {
+			if errors.Is(err, domain.ErrIndexNotFound) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
-			} else if err.Error() == "document not found" {
+			} else if errors.Is(err, domain.ErrDocumentNotFound) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "Document not found"})
 			} else {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -193,7 +195,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		indexName := c.Param("index")
 		count, err := app.DocumentService.CountDocuments(c.Request.Context(), indexName)
 		if err != nil {
-			if err.Error() == "index not found" {
+			if errors.Is(err, domain.ErrIndexNotFound) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
 			} else {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -208,7 +210,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		search := c.Query("search")
 		results, err := app.DocumentService.SearchDocuments(c.Request.Context(), indexName, search)
 		if err != nil {
-			if err.Error() == "index not found" {
+			if errors.Is(err, domain.ErrIndexNotFound) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
 			} else {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -228,7 +230,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		}
 		results, err := app.DocumentService.SearchDocuments(c.Request.Context(), indexName, req.Search)
 		if err != nil {
-			if err.Error() == "index not found" {
+			if errors.Is(err, domain.ErrIndexNotFound) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
 			} else {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/internal/application/document_service.go
+++ b/internal/application/document_service.go
@@ -24,7 +24,7 @@ func (s *DocumentService) AddOrUpdateSingleDoc(ctx context.Context, indexName st
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("index not found")
+		return domain.ErrIndexNotFound
 	}
 	// キーフィールド名を取得
 	idx, err := s.IdxRepo.FindByName(indexName)
@@ -48,11 +48,11 @@ func (s *DocumentService) AddOrUpdateSingleDoc(ctx context.Context, indexName st
 		}
 	}
 	if keyField == "" {
-		return fmt.Errorf("missing key field")
+		return domain.ErrMissingKeyField
 	}
 	keyVal, ok := doc[keyField]
 	if !ok {
-		return fmt.Errorf("missing key field")
+		return domain.ErrMissingKeyField
 	}
 	keyStr, ok := keyVal.(string)
 	if !ok {
@@ -72,9 +72,8 @@ func (s *DocumentService) BatchOperation(ctx context.Context, indexName string, 
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("index not found")
+		return nil, domain.ErrIndexNotFound
 	}
-	// キーフィールド名を取得
 	idx, err := s.IdxRepo.FindByName(indexName)
 	if err != nil {
 		return nil, err
@@ -96,7 +95,7 @@ func (s *DocumentService) BatchOperation(ctx context.Context, indexName string, 
 		}
 	}
 	if keyField == "" {
-		return nil, fmt.Errorf("missing key field")
+		return nil, domain.ErrMissingKeyField
 	}
 	results := make([]map[string]interface{}, 0, len(docs))
 	for _, d := range docs {
@@ -152,7 +151,7 @@ func (s *DocumentService) SearchDocuments(ctx context.Context, indexName string,
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("index not found")
+		return nil, domain.ErrIndexNotFound
 	}
 	docs, err := s.DocRepo.List(indexName)
 	if err != nil {
@@ -187,13 +186,10 @@ func (s *DocumentService) GetDocument(ctx context.Context, indexName, key string
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("index not found")
+		return nil, domain.ErrIndexNotFound
 	}
 	doc, err := s.DocRepo.Find(indexName, key)
 	if err != nil {
-		if err == domain.ErrDocumentNotFound {
-			return nil, fmt.Errorf("document not found")
-		}
 		return nil, err
 	}
 	var m map[string]interface{}
@@ -209,7 +205,7 @@ func (s *DocumentService) CountDocuments(ctx context.Context, indexName string) 
 		return 0, err
 	}
 	if !exists {
-		return 0, fmt.Errorf("index not found")
+		return 0, domain.ErrIndexNotFound
 	}
 	return s.DocRepo.Count(indexName)
 }

--- a/internal/application/index_service.go
+++ b/internal/application/index_service.go
@@ -27,7 +27,7 @@ func (s *IndexService) CreateIndex(ctx context.Context, name string, body io.Rea
 		return err
 	}
 	if exists {
-		return fmt.Errorf("already exists")
+		return domain.ErrIndexAlreadyExists
 	}
 
 	// bodyからスキーマJSONを読み込む
@@ -90,9 +90,6 @@ func (s *IndexService) ListIndexes(ctx context.Context, selectFields string) ([]
 func (s *IndexService) GetIndex(ctx context.Context, name string) (map[string]interface{}, error) {
 	idx, err := s.Repo.FindByName(name)
 	if err != nil {
-		if err == domain.ErrIndexNotFound {
-			return nil, fmt.Errorf("index not found")
-		}
 		return nil, err
 	}
 	var schema map[string]interface{}
@@ -139,9 +136,6 @@ func (s *IndexService) UpdateIndex(ctx context.Context, name string, body io.Rea
 	defer body.Close()
 	idx, err := s.Repo.FindByName(name)
 	if err != nil {
-		if err == domain.ErrIndexNotFound {
-			return fmt.Errorf("index not found")
-		}
 		return err
 	}
 	schemaBytes, err := io.ReadAll(body)
@@ -163,23 +157,12 @@ func (s *IndexService) UpdateIndex(ctx context.Context, name string, body io.Rea
 }
 
 func (s *IndexService) DeleteIndex(ctx context.Context, name string) error {
-	err := s.Repo.Delete(name)
-	if err != nil {
-		if err == domain.ErrIndexNotFound {
-			return fmt.Errorf("index not found")
-		}
-		return err
-	}
-	return nil
+	return s.Repo.Delete(name)
 }
 
 func (s *IndexService) GetIndexStats(ctx context.Context, name string) (map[string]interface{}, error) {
-	// インデックス存在チェック
 	_, err := s.Repo.FindByName(name)
 	if err != nil {
-		if err == domain.ErrIndexNotFound {
-			return nil, fmt.Errorf("index not found")
-		}
 		return nil, err
 	}
 	// ドキュメント件数取得

--- a/internal/application/index_service_test.go
+++ b/internal/application/index_service_test.go
@@ -56,8 +56,8 @@ func TestIndexService_CreateIndex_AlreadyExists(t *testing.T) {
 	_ = idxRepo.Create(&domain.Index{Name: "my-index", Schema: validSchemaJSON})
 
 	err := svc.CreateIndex(context.Background(), "my-index", body(validSchemaJSON))
-	if err == nil || err.Error() != "already exists" {
-		t.Fatalf("expected 'already exists' error, got %v", err)
+	if !errors.Is(err, domain.ErrIndexAlreadyExists) {
+		t.Fatalf("expected ErrIndexAlreadyExists, got %v", err)
 	}
 }
 
@@ -245,7 +245,7 @@ func TestIndexService_GetIndex_RepoError(t *testing.T) {
 	svc, idxRepo, _ := newIndexServiceForTest()
 	idxRepo.findErr = errors.New("boom")
 	_, err := svc.GetIndex(context.Background(), "x")
-	if err == nil || err.Error() == "index not found" {
+	if err == nil || errors.Is(err, domain.ErrIndexNotFound) {
 		t.Fatalf("expected raw repo error to bubble up, got %v", err)
 	}
 }
@@ -323,7 +323,7 @@ func TestIndexService_DeleteIndex_RepoError(t *testing.T) {
 	svc, idxRepo, _ := newIndexServiceForTest()
 	idxRepo.deleteErr = errors.New("db error")
 	err := svc.DeleteIndex(context.Background(), "anything")
-	if err == nil || err.Error() == "index not found" {
+	if err == nil || errors.Is(err, domain.ErrIndexNotFound) {
 		t.Fatalf("expected db error to bubble up, got %v", err)
 	}
 }

--- a/internal/domain/document.go
+++ b/internal/domain/document.go
@@ -3,6 +3,7 @@ package domain
 import "errors"
 
 var ErrDocumentNotFound = errors.New("document not found")
+var ErrMissingKeyField = errors.New("missing key field")
 
 type Document struct {
 	IndexName string

--- a/internal/domain/index.go
+++ b/internal/domain/index.go
@@ -3,6 +3,7 @@ package domain
 import "errors"
 
 var ErrIndexNotFound = errors.New("index not found")
+var ErrIndexAlreadyExists = errors.New("index already exists")
 
 type Index struct {
 	Name   string


### PR DESCRIPTION
## Summary

Closes #6.

- `domain.ErrIndexAlreadyExists` and `domain.ErrMissingKeyField` を新規追加（`ErrIndexNotFound`・`ErrDocumentNotFound` は既存）
- `application` 層：`fmt.Errorf("index not found")` のような文字列ラップをやめ、センチネルをそのまま return
- `handler.go`：`err.Error() == "..."` の文字列比較を全て `errors.Is(err, domain.Err...)` に置換
- テスト：`err.Error() !=` / `err.Error() ==` による比較を `errors.Is` に更新

## Test plan

- [ ] `mise exec -- go test -race ./...` が全 PASS
- [ ] `TestCreateIndex_DuplicateReturns409` — 409 が依然返ること
- [ ] `TestGetIndex_NotFound` / `TestDeleteIndex_NotFound` / etc. — 404 が依然返ること
- [ ] `TestAddSingleDoc_MissingKey` — 400 が依然返ること
- [ ] `TestGetDocument_DocNotFound` — 404 が依然返ること