### PR TITLE
feat: OData query parameters for search endpoints (#7)

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -10,6 +10,8 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -29,8 +31,8 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			return
 		}
 		var req struct {
-			Name      string      `json:"name" binding:"required"`
-			Fields    interface{} `json:"fields" binding:"required"`
+			Name       string      `json:"name" binding:"required"`
+			Fields     interface{} `json:"fields" binding:"required"`
 			Suggesters interface{} `json:"suggesters,omitempty"`
 			Analyzers  interface{} `json:"analyzers,omitempty"`
 		}
@@ -78,7 +80,6 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
-		// Azure仕様に合わせてvalue配列で返却
 		c.JSON(http.StatusOK, gin.H{"value": indexes})
 	})
 	// インデックス取得API
@@ -211,41 +212,147 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		}
 		c.String(http.StatusOK, "%d", count)
 	})
-	// ドキュメント検索API
+	// ドキュメント検索API (GET)
 	r.GET("/indexes/:index/docs", func(c *gin.Context) {
 		indexName := c.Param("index")
-		search := c.Query("search")
-		results, err := app.DocumentService.SearchDocuments(c.Request.Context(), indexName, search)
+		params := parseSearchParamsFromQuery(c)
+		result, err := app.DocumentService.SearchDocuments(c.Request.Context(), indexName, params)
 		if err != nil {
-			if errors.Is(err, domain.ErrIndexNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
-			} else {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			}
+			handleSearchError(c, err)
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{"value": results})
+		respondSearch(c, result, params.IncludeCount)
 	})
+	// ドキュメント検索API (POST)
 	r.POST("/indexes/:index/docs/search", func(c *gin.Context) {
 		indexName := c.Param("index")
-		var req struct {
-			Search string `json:"search"`
-		}
-		if err := c.ShouldBindJSON(&req); err != nil {
+		params, err := parseSearchParamsFromBody(c)
+		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
 			return
 		}
-		results, err := app.DocumentService.SearchDocuments(c.Request.Context(), indexName, req.Search)
+		result, err := app.DocumentService.SearchDocuments(c.Request.Context(), indexName, params)
 		if err != nil {
-			if errors.Is(err, domain.ErrIndexNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
-			} else {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			}
+			handleSearchError(c, err)
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{"value": results})
+		respondSearch(c, result, params.IncludeCount)
 	})
+}
+
+// parseSearchParamsFromQuery reads OData parameters from GET query string.
+func parseSearchParamsFromQuery(c *gin.Context) application.SearchParams {
+	top, _ := strconv.Atoi(c.Query("$top"))
+	skip, _ := strconv.Atoi(c.Query("$skip"))
+	count := strings.EqualFold(c.Query("$count"), "true")
+
+	var selectFields []string
+	if s := c.Query("$select"); s != "" {
+		for _, f := range strings.Split(s, ",") {
+			if f = strings.TrimSpace(f); f != "" {
+				selectFields = append(selectFields, f)
+			}
+		}
+	}
+
+	var searchFields []string
+	if s := c.Query("searchFields"); s != "" {
+		for _, f := range strings.Split(s, ",") {
+			if f = strings.TrimSpace(f); f != "" {
+				searchFields = append(searchFields, f)
+			}
+		}
+	}
+
+	return application.SearchParams{
+		Search:       c.Query("search"),
+		Filter:       c.Query("$filter"),
+		OrderBy:      c.Query("$orderby"),
+		Select:       selectFields,
+		SearchFields: searchFields,
+		Top:          top,
+		Skip:         skip,
+		IncludeCount: count,
+	}
+}
+
+// searchBody mirrors the Azure AI Search POST /docs/search request body.
+type searchBody struct {
+	Search       string `json:"search"`
+	Filter       string `json:"$filter"`
+	OrderBy      string `json:"$orderby"`
+	Select       string `json:"$select"`
+	SearchFields string `json:"searchFields"`
+	Top          *int   `json:"$top"`
+	Skip         *int   `json:"$skip"`
+	Count        bool   `json:"$count"`
+}
+
+// parseSearchParamsFromBody reads OData parameters from a POST JSON body.
+func parseSearchParamsFromBody(c *gin.Context) (application.SearchParams, error) {
+	var b searchBody
+	if err := c.ShouldBindJSON(&b); err != nil {
+		return application.SearchParams{}, err
+	}
+
+	top := 0
+	if b.Top != nil {
+		top = *b.Top
+	}
+	skip := 0
+	if b.Skip != nil {
+		skip = *b.Skip
+	}
+
+	var selectFields []string
+	if b.Select != "" {
+		for _, f := range strings.Split(b.Select, ",") {
+			if f = strings.TrimSpace(f); f != "" {
+				selectFields = append(selectFields, f)
+			}
+		}
+	}
+
+	var searchFields []string
+	if b.SearchFields != "" {
+		for _, f := range strings.Split(b.SearchFields, ",") {
+			if f = strings.TrimSpace(f); f != "" {
+				searchFields = append(searchFields, f)
+			}
+		}
+	}
+
+	return application.SearchParams{
+		Search:       b.Search,
+		Filter:       b.Filter,
+		OrderBy:      b.OrderBy,
+		Select:       selectFields,
+		SearchFields: searchFields,
+		Top:          top,
+		Skip:         skip,
+		IncludeCount: b.Count,
+	}, nil
+}
+
+func handleSearchError(c *gin.Context, err error) {
+	if errors.Is(err, domain.ErrIndexNotFound) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
+		return
+	}
+	msg := err.Error()
+	if strings.HasPrefix(msg, "invalid $filter") || strings.HasPrefix(msg, "invalid $orderby") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+	c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+}
+
+func respondSearch(c *gin.Context, result *application.SearchResult, includeCount bool) {
+	resp := gin.H{"value": result.Value}
+	if includeCount {
+		resp["@odata.count"] = result.Total
+	}
+	c.JSON(http.StatusOK, resp)
 }
 
 func ApiKeyAuthMiddleware() gin.HandlerFunc {
@@ -255,13 +362,13 @@ func ApiKeyAuthMiddleware() gin.HandlerFunc {
 	}
 	return func(c *gin.Context) {
 		apiKey := c.GetHeader("api-key")
-        if apiKey == "" {
-            apiKey = c.GetHeader("Api-Key")
-        }
-        if apiKeyEnv == "" || apiKey != apiKeyEnv {
-            c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "API key required or invalid"})
-            return
-        }
-        c.Next()
+		if apiKey == "" {
+			apiKey = c.GetHeader("Api-Key")
+		}
+		if apiKeyEnv == "" || apiKey != apiKeyEnv {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "API key required or invalid"})
+			return
+		}
+		c.Next()
 	}
 }

--- a/internal/application/document_service.go
+++ b/internal/application/document_service.go
@@ -11,8 +11,8 @@ import (
 )
 
 type DocumentService struct {
-	DocRepo   domain.DocumentRepository
-	IdxRepo   domain.IndexRepository
+	DocRepo domain.DocumentRepository
+	IdxRepo domain.IndexRepository
 }
 
 func NewDocumentService(docRepo domain.DocumentRepository, idxRepo domain.IndexRepository) *DocumentService {
@@ -20,7 +20,6 @@ func NewDocumentService(docRepo domain.DocumentRepository, idxRepo domain.IndexR
 }
 
 func (s *DocumentService) AddOrUpdateSingleDoc(ctx context.Context, indexName string, doc map[string]interface{}) error {
-	// インデックス存在チェック
 	exists, err := s.IdxRepo.Exists(indexName)
 	if err != nil {
 		return err
@@ -28,29 +27,9 @@ func (s *DocumentService) AddOrUpdateSingleDoc(ctx context.Context, indexName st
 	if !exists {
 		return domain.ErrIndexNotFound
 	}
-	// キーフィールド名を取得
-	idx, err := s.IdxRepo.FindByName(indexName)
+	keyField, err := s.keyField(indexName)
 	if err != nil {
 		return err
-	}
-	var schema struct {
-		Fields []struct {
-			Name string `json:"name"`
-			Key  bool   `json:"key"`
-		}
-	}
-	if err := json.Unmarshal([]byte(idx.Schema), &schema); err != nil {
-		return fmt.Errorf("schema parse error")
-	}
-	keyField := ""
-	for _, f := range schema.Fields {
-		if f.Key {
-			keyField = f.Name
-			break
-		}
-	}
-	if keyField == "" {
-		return domain.ErrMissingKeyField
 	}
 	keyVal, ok := doc[keyField]
 	if !ok {
@@ -76,28 +55,9 @@ func (s *DocumentService) BatchOperation(ctx context.Context, indexName string, 
 	if !exists {
 		return nil, domain.ErrIndexNotFound
 	}
-	idx, err := s.IdxRepo.FindByName(indexName)
+	keyField, err := s.keyField(indexName)
 	if err != nil {
 		return nil, err
-	}
-	var schema struct {
-		Fields []struct {
-			Name string `json:"name"`
-			Key  bool   `json:"key"`
-		}
-	}
-	if err := json.Unmarshal([]byte(idx.Schema), &schema); err != nil {
-		return nil, fmt.Errorf("schema parse error")
-	}
-	keyField := ""
-	for _, f := range schema.Fields {
-		if f.Key {
-			keyField = f.Name
-			break
-		}
-	}
-	if keyField == "" {
-		return nil, domain.ErrMissingKeyField
 	}
 
 	results := make([]map[string]interface{}, 0, len(docs))
@@ -192,7 +152,8 @@ func batchError(key string, statusCode int, message string) map[string]interface
 	return r
 }
 
-func (s *DocumentService) SearchDocuments(ctx context.Context, indexName string, search string) ([]map[string]interface{}, error) {
+// SearchDocuments executes a search using the provided OData parameters.
+func (s *DocumentService) SearchDocuments(ctx context.Context, indexName string, params SearchParams) (*SearchResult, error) {
 	exists, err := s.IdxRepo.Exists(indexName)
 	if err != nil {
 		return nil, err
@@ -200,31 +161,51 @@ func (s *DocumentService) SearchDocuments(ctx context.Context, indexName string,
 	if !exists {
 		return nil, domain.ErrIndexNotFound
 	}
-	docs, err := s.DocRepo.List(indexName)
+
+	opts := domain.SearchOptions{
+		TextSearch:       params.Search,
+		TextSearchFields: params.SearchFields,
+		Top:              params.Top,
+		Skip:             params.Skip,
+	}
+	if opts.Top <= 0 {
+		opts.Top = defaultTop
+	}
+
+	if params.Filter != "" {
+		whereSQL, whereArgs, err := ParseODataFilter(params.Filter)
+		if err != nil {
+			return nil, fmt.Errorf("invalid $filter: %w", err)
+		}
+		opts.WhereSQL = whereSQL
+		opts.WhereArgs = whereArgs
+	}
+
+	if params.OrderBy != "" {
+		orderSQL, err := ParseODataOrderBy(params.OrderBy)
+		if err != nil {
+			return nil, fmt.Errorf("invalid $orderby: %w", err)
+		}
+		opts.OrderSQL = orderSQL
+	}
+
+	docs, total, err := s.DocRepo.Search(indexName, opts)
 	if err != nil {
 		return nil, err
 	}
-	var results []map[string]interface{}
+
+	results := make([]map[string]interface{}, 0, len(docs))
 	for _, doc := range docs {
-		if search == "" || contains(doc.Content, search) {
-			var m map[string]interface{}
-			if err := json.Unmarshal([]byte(doc.Content), &m); err == nil {
-				results = append(results, m)
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(doc.Content), &m); err == nil {
+			if len(params.Select) > 0 {
+				m = selectFields(m, params.Select)
 			}
+			results = append(results, m)
 		}
 	}
-	return results, nil
-}
 
-// Content(JSON文字列)に部分一致するか判定（大文字小文字無視）
-func contains(content string, search string) bool {
-	if search == "" {
-		return true
-	}
-	if search == "*" {
-		return true
-	}
-	return strings.Contains(strings.ToLower(content), strings.ToLower(search))
+	return &SearchResult{Value: results, Total: total}, nil
 }
 
 func (s *DocumentService) GetDocument(ctx context.Context, indexName, key string) (map[string]interface{}, error) {
@@ -255,4 +236,49 @@ func (s *DocumentService) CountDocuments(ctx context.Context, indexName string) 
 		return 0, domain.ErrIndexNotFound
 	}
 	return s.DocRepo.Count(indexName)
+}
+
+// keyField extracts the name of the key field from the index schema.
+func (s *DocumentService) keyField(indexName string) (string, error) {
+	idx, err := s.IdxRepo.FindByName(indexName)
+	if err != nil {
+		return "", err
+	}
+	var schema struct {
+		Fields []struct {
+			Name string `json:"name"`
+			Key  bool   `json:"key"`
+		}
+	}
+	if err := json.Unmarshal([]byte(idx.Schema), &schema); err != nil {
+		return "", fmt.Errorf("schema parse error")
+	}
+	for _, f := range schema.Fields {
+		if f.Key {
+			return f.Name, nil
+		}
+	}
+	return "", domain.ErrMissingKeyField
+}
+
+// selectFields returns a new map containing only the requested fields.
+func selectFields(m map[string]interface{}, fields []string) map[string]interface{} {
+	result := make(map[string]interface{}, len(fields))
+	for _, f := range fields {
+		if v, ok := m[f]; ok {
+			result[f] = v
+		}
+	}
+	return result
+}
+
+// contains reports whether content includes the search term (case-insensitive).
+func contains(content string, search string) bool {
+	if search == "" {
+		return true
+	}
+	if search == "*" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(content), strings.ToLower(search))
 }

--- a/internal/application/document_service_test.go
+++ b/internal/application/document_service_test.go
@@ -80,7 +80,6 @@ func TestDocumentService_AddOrUpdateSingleDoc_NonStringKey(t *testing.T) {
 func TestDocumentService_AddOrUpdateSingleDoc_NoKeyInSchema(t *testing.T) {
 	t.Parallel()
 	svc, idxRepo, _ := newDocumentServiceForTest()
-	// Schema with no key=true field.
 	_ = idxRepo.Create(&domain.Index{
 		Name:   "no-key",
 		Schema: `{"fields":[{"name":"id","key":false}]}`,
@@ -367,6 +366,15 @@ func TestDocumentService_BatchOperation_BadSchema(t *testing.T) {
 
 // --- SearchDocuments ---
 
+func searchAll(t *testing.T, svc *DocumentService, indexName string) *SearchResult {
+	t.Helper()
+	res, err := svc.SearchDocuments(context.Background(), indexName, SearchParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return res
+}
+
 func TestDocumentService_SearchDocuments_NoFilter(t *testing.T) {
 	t.Parallel()
 	svc, idxRepo, docRepo := newDocumentServiceForTest()
@@ -374,12 +382,12 @@ func TestDocumentService_SearchDocuments_NoFilter(t *testing.T) {
 	_ = docRepo.Upsert(&domain.Document{IndexName: "idx", Key: "1", Content: `{"id":"1","title":"alpha"}`})
 	_ = docRepo.Upsert(&domain.Document{IndexName: "idx", Key: "2", Content: `{"id":"2","title":"beta"}`})
 
-	results, err := svc.SearchDocuments(context.Background(), "idx", "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	res := searchAll(t, svc, "idx")
+	if len(res.Value) != 2 {
+		t.Errorf("expected 2 results, got %d", len(res.Value))
 	}
-	if len(results) != 2 {
-		t.Errorf("expected 2 results, got %d", len(results))
+	if res.Total != 2 {
+		t.Errorf("total = %d, want 2", res.Total)
 	}
 }
 
@@ -389,12 +397,12 @@ func TestDocumentService_SearchDocuments_Wildcard(t *testing.T) {
 	seedIndex(t, idxRepo, "idx")
 	_ = docRepo.Upsert(&domain.Document{IndexName: "idx", Key: "1", Content: `{"id":"1"}`})
 
-	results, err := svc.SearchDocuments(context.Background(), "idx", "*")
+	res, err := svc.SearchDocuments(context.Background(), "idx", SearchParams{Search: "*"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(results) != 1 {
-		t.Errorf("expected 1 result, got %d", len(results))
+	if len(res.Value) != 1 {
+		t.Errorf("expected 1 result, got %d", len(res.Value))
 	}
 }
 
@@ -405,15 +413,15 @@ func TestDocumentService_SearchDocuments_CaseInsensitive(t *testing.T) {
 	_ = docRepo.Upsert(&domain.Document{IndexName: "idx", Key: "1", Content: `{"id":"1","title":"Alpha"}`})
 	_ = docRepo.Upsert(&domain.Document{IndexName: "idx", Key: "2", Content: `{"id":"2","title":"Beta"}`})
 
-	results, err := svc.SearchDocuments(context.Background(), "idx", "ALPHA")
+	res, err := svc.SearchDocuments(context.Background(), "idx", SearchParams{Search: "ALPHA"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(results) != 1 {
-		t.Errorf("expected 1 result, got %d", len(results))
+	if len(res.Value) != 1 {
+		t.Errorf("expected 1 result, got %d", len(res.Value))
 	}
-	if results[0]["title"] != "Alpha" {
-		t.Errorf("expected title=Alpha, got %v", results[0]["title"])
+	if res.Value[0]["title"] != "Alpha" {
+		t.Errorf("expected title=Alpha, got %v", res.Value[0]["title"])
 	}
 }
 
@@ -423,19 +431,19 @@ func TestDocumentService_SearchDocuments_NoMatch(t *testing.T) {
 	seedIndex(t, idxRepo, "idx")
 	_ = docRepo.Upsert(&domain.Document{IndexName: "idx", Key: "1", Content: `{"id":"1","title":"alpha"}`})
 
-	results, err := svc.SearchDocuments(context.Background(), "idx", "zzz")
+	res, err := svc.SearchDocuments(context.Background(), "idx", SearchParams{Search: "zzz"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(results) != 0 {
-		t.Errorf("expected 0 results, got %d", len(results))
+	if len(res.Value) != 0 {
+		t.Errorf("expected 0 results, got %d", len(res.Value))
 	}
 }
 
 func TestDocumentService_SearchDocuments_IndexNotFound(t *testing.T) {
 	t.Parallel()
 	svc, _, _ := newDocumentServiceForTest()
-	_, err := svc.SearchDocuments(context.Background(), "missing", "x")
+	_, err := svc.SearchDocuments(context.Background(), "missing", SearchParams{Search: "x"})
 	if err == nil || err.Error() != "index not found" {
 		t.Fatalf("expected 'index not found', got %v", err)
 	}
@@ -445,17 +453,82 @@ func TestDocumentService_SearchDocuments_SkipsBadJSON(t *testing.T) {
 	t.Parallel()
 	svc, idxRepo, docRepo := newDocumentServiceForTest()
 	seedIndex(t, idxRepo, "idx")
-	// Insert raw broken JSON via the mock store directly.
 	docRepo.store["idx"] = map[string]*domain.Document{
 		"bad":  {IndexName: "idx", Key: "bad", Content: "not-json"},
 		"good": {IndexName: "idx", Key: "good", Content: `{"id":"good"}`},
 	}
-	results, err := svc.SearchDocuments(context.Background(), "idx", "")
+	res, err := svc.SearchDocuments(context.Background(), "idx", SearchParams{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(results) != 1 {
-		t.Errorf("expected 1 valid result (bad JSON skipped), got %d", len(results))
+	if len(res.Value) != 1 {
+		t.Errorf("expected 1 valid result (bad JSON skipped), got %d", len(res.Value))
+	}
+}
+
+func TestDocumentService_SearchDocuments_Select(t *testing.T) {
+	t.Parallel()
+	svc, idxRepo, docRepo := newDocumentServiceForTest()
+	seedIndex(t, idxRepo, "idx")
+	_ = docRepo.Upsert(&domain.Document{IndexName: "idx", Key: "1", Content: `{"id":"1","title":"T","notes":"N"}`})
+
+	res, err := svc.SearchDocuments(context.Background(), "idx", SearchParams{Select: []string{"id", "title"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Value) != 1 {
+		t.Fatalf("expected 1 result")
+	}
+	if _, ok := res.Value[0]["notes"]; ok {
+		t.Errorf("notes should be excluded by $select")
+	}
+	if res.Value[0]["title"] != "T" {
+		t.Errorf("title should be included, got %v", res.Value[0])
+	}
+}
+
+func TestDocumentService_SearchDocuments_TopSkip(t *testing.T) {
+	t.Parallel()
+	svc, idxRepo, docRepo := newDocumentServiceForTest()
+	seedIndex(t, idxRepo, "idx")
+	for i := 1; i <= 5; i++ {
+		_ = docRepo.Upsert(&domain.Document{
+			IndexName: "idx", Key: strings.Repeat("x", i),
+			Content: `{"id":"x"}`,
+		})
+	}
+
+	res, err := svc.SearchDocuments(context.Background(), "idx", SearchParams{Top: 2, Skip: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Total != 5 {
+		t.Errorf("total = %d, want 5", res.Total)
+	}
+	if len(res.Value) != 2 {
+		t.Errorf("len(value) = %d, want 2", len(res.Value))
+	}
+}
+
+func TestDocumentService_SearchDocuments_InvalidFilter(t *testing.T) {
+	t.Parallel()
+	svc, idxRepo, _ := newDocumentServiceForTest()
+	seedIndex(t, idxRepo, "idx")
+
+	_, err := svc.SearchDocuments(context.Background(), "idx", SearchParams{Filter: "Field xyz 'v'"})
+	if err == nil || !strings.Contains(err.Error(), "$filter") {
+		t.Fatalf("expected $filter error, got %v", err)
+	}
+}
+
+func TestDocumentService_SearchDocuments_InvalidOrderBy(t *testing.T) {
+	t.Parallel()
+	svc, idxRepo, _ := newDocumentServiceForTest()
+	seedIndex(t, idxRepo, "idx")
+
+	_, err := svc.SearchDocuments(context.Background(), "idx", SearchParams{OrderBy: "Rating sideways"})
+	if err == nil || !strings.Contains(err.Error(), "$orderby") {
+		t.Fatalf("expected $orderby error, got %v", err)
 	}
 }
 

--- a/internal/application/mock_test.go
+++ b/internal/application/mock_test.go
@@ -116,6 +116,7 @@ type mockDocumentRepository struct {
 	deleteErr error
 	listErr   error
 	countErr  error
+	searchErr error
 }
 
 func newMockDocumentRepository() *mockDocumentRepository {
@@ -198,4 +199,45 @@ func (m *mockDocumentRepository) Count(indexName string) (int, error) {
 		return len(docs), nil
 	}
 	return 0, nil
+}
+
+// Search implements domain.DocumentRepository for unit tests.
+// It applies in-memory text search and pagination; WhereSQL/OrderSQL are ignored
+// (SQL-level filter behavior is tested via the SQLite repository integration tests).
+func (m *mockDocumentRepository) Search(indexName string, opts domain.SearchOptions) ([]*domain.Document, int64, error) {
+	if m.searchErr != nil {
+		return nil, 0, m.searchErr
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var all []*domain.Document
+	if docs, ok := m.store[indexName]; ok {
+		for _, doc := range docs {
+			if contains(doc.Content, opts.TextSearch) {
+				all = append(all, &domain.Document{
+					IndexName: doc.IndexName,
+					Key:       doc.Key,
+					Content:   doc.Content,
+				})
+			}
+		}
+	}
+
+	total := int64(len(all))
+
+	if opts.Skip > 0 {
+		if opts.Skip >= len(all) {
+			return []*domain.Document{}, total, nil
+		}
+		all = all[opts.Skip:]
+	}
+	top := opts.Top
+	if top <= 0 {
+		top = 50
+	}
+	if top < len(all) {
+		all = all[:top]
+	}
+	return all, total, nil
 }

--- a/internal/application/odata_filter.go
+++ b/internal/application/odata_filter.go
@@ -1,0 +1,412 @@
+package application
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// ParseODataFilter parses an OData $filter expression and returns a SQL WHERE
+// fragment (no WHERE keyword) using json_extract() for SQLite document blobs,
+// plus the corresponding bind arguments.
+func ParseODataFilter(filter string) (string, []interface{}, error) {
+	p := &filterParser{input: strings.TrimSpace(filter)}
+	sql, args, err := p.parseOrExpr()
+	if err != nil {
+		return "", nil, err
+	}
+	p.skipSpaces()
+	if p.pos < len(p.input) {
+		return "", nil, fmt.Errorf("unexpected input at position %d: %q", p.pos, p.input[p.pos:])
+	}
+	return sql, args, nil
+}
+
+// ParseODataOrderBy parses an OData $orderby expression and returns an SQL
+// ORDER BY fragment (no ORDER BY keyword).
+func ParseODataOrderBy(orderby string) (string, error) {
+	parts := strings.Split(orderby, ",")
+	sqlParts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		fields := strings.Fields(part)
+		fieldSQL := jsonExtract(fields[0])
+		dir := "ASC"
+		if len(fields) >= 2 {
+			switch strings.ToLower(fields[1]) {
+			case "desc":
+				dir = "DESC"
+			case "asc":
+				dir = "ASC"
+			default:
+				return "", fmt.Errorf("invalid sort direction: %q", fields[1])
+			}
+		}
+		sqlParts = append(sqlParts, fieldSQL+" "+dir)
+	}
+	return strings.Join(sqlParts, ", "), nil
+}
+
+func jsonExtract(field string) string {
+	return fmt.Sprintf("json_extract(content, '$.%s')", field)
+}
+
+// filterParser is a recursive-descent parser for OData $filter expressions.
+type filterParser struct {
+	input string
+	pos   int
+}
+
+func (p *filterParser) skipSpaces() {
+	for p.pos < len(p.input) && unicode.IsSpace(rune(p.input[p.pos])) {
+		p.pos++
+	}
+}
+
+// parseOrExpr handles: expr ('or' expr)*
+func (p *filterParser) parseOrExpr() (string, []interface{}, error) {
+	left, args, err := p.parseAndExpr()
+	if err != nil {
+		return "", nil, err
+	}
+	for {
+		p.skipSpaces()
+		if !p.peekKeyword("or") {
+			break
+		}
+		p.consumeKeyword("or")
+		right, rightArgs, err := p.parseAndExpr()
+		if err != nil {
+			return "", nil, err
+		}
+		left = "(" + left + " OR " + right + ")"
+		args = append(args, rightArgs...)
+	}
+	return left, args, nil
+}
+
+// parseAndExpr handles: expr ('and' expr)*
+func (p *filterParser) parseAndExpr() (string, []interface{}, error) {
+	left, args, err := p.parseNotExpr()
+	if err != nil {
+		return "", nil, err
+	}
+	for {
+		p.skipSpaces()
+		if !p.peekKeyword("and") {
+			break
+		}
+		p.consumeKeyword("and")
+		right, rightArgs, err := p.parseNotExpr()
+		if err != nil {
+			return "", nil, err
+		}
+		left = "(" + left + " AND " + right + ")"
+		args = append(args, rightArgs...)
+	}
+	return left, args, nil
+}
+
+// parseNotExpr handles: ['not'] primary
+func (p *filterParser) parseNotExpr() (string, []interface{}, error) {
+	p.skipSpaces()
+	if p.peekKeyword("not") {
+		p.consumeKeyword("not")
+		inner, args, err := p.parsePrimary()
+		if err != nil {
+			return "", nil, err
+		}
+		return "NOT (" + inner + ")", args, nil
+	}
+	return p.parsePrimary()
+}
+
+func (p *filterParser) parsePrimary() (string, []interface{}, error) {
+	p.skipSpaces()
+	if p.pos >= len(p.input) {
+		return "", nil, fmt.Errorf("unexpected end of filter expression")
+	}
+	if p.input[p.pos] == '(' {
+		p.pos++
+		sql, args, err := p.parseOrExpr()
+		if err != nil {
+			return "", nil, err
+		}
+		p.skipSpaces()
+		if p.pos >= len(p.input) || p.input[p.pos] != ')' {
+			return "", nil, fmt.Errorf("expected ')' at position %d", p.pos)
+		}
+		p.pos++
+		return sql, args, nil
+	}
+	if p.peekFunc("search.in") {
+		return p.parseSearchIn()
+	}
+	if p.peekFunc("startswith") {
+		return p.parseStartsWith()
+	}
+	return p.parseComparison()
+}
+
+func (p *filterParser) peekKeyword(kw string) bool {
+	p.skipSpaces()
+	end := p.pos + len(kw)
+	if end > len(p.input) {
+		return false
+	}
+	if !strings.EqualFold(p.input[p.pos:end], kw) {
+		return false
+	}
+	// Must be followed by whitespace or end-of-input (word boundary).
+	if end < len(p.input) && isIdentRune(rune(p.input[end])) {
+		return false
+	}
+	return true
+}
+
+func (p *filterParser) consumeKeyword(kw string) {
+	p.skipSpaces()
+	p.pos += len(kw)
+}
+
+func (p *filterParser) peekFunc(name string) bool {
+	p.skipSpaces()
+	remaining := p.input[p.pos:]
+	return len(remaining) >= len(name)+1 &&
+		strings.EqualFold(remaining[:len(name)], name) &&
+		remaining[len(name)] == '('
+}
+
+func isIdentRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '.'
+}
+
+func (p *filterParser) parseIdentifier() (string, error) {
+	p.skipSpaces()
+	start := p.pos
+	for p.pos < len(p.input) && isIdentRune(rune(p.input[p.pos])) {
+		p.pos++
+	}
+	if p.pos == start {
+		return "", fmt.Errorf("expected identifier at position %d", p.pos)
+	}
+	return p.input[start:p.pos], nil
+}
+
+func (p *filterParser) parseStringLiteral() (string, error) {
+	p.skipSpaces()
+	if p.pos >= len(p.input) || p.input[p.pos] != '\'' {
+		return "", fmt.Errorf("expected string literal (single-quoted) at position %d", p.pos)
+	}
+	p.pos++ // consume opening '
+	var sb strings.Builder
+	for p.pos < len(p.input) {
+		if p.input[p.pos] == '\'' {
+			if p.pos+1 < len(p.input) && p.input[p.pos+1] == '\'' {
+				sb.WriteByte('\'')
+				p.pos += 2
+			} else {
+				p.pos++ // consume closing '
+				return sb.String(), nil
+			}
+		} else {
+			sb.WriteByte(p.input[p.pos])
+			p.pos++
+		}
+	}
+	return "", fmt.Errorf("unterminated string literal")
+}
+
+func (p *filterParser) parseComparison() (string, []interface{}, error) {
+	field, err := p.parseIdentifier()
+	if err != nil {
+		return "", nil, err
+	}
+	p.skipSpaces()
+
+	// Read the operator token (non-space sequence).
+	opStart := p.pos
+	for p.pos < len(p.input) && !unicode.IsSpace(rune(p.input[p.pos])) {
+		p.pos++
+	}
+	op := strings.ToLower(p.input[opStart:p.pos])
+	sqlOp, ok := map[string]string{
+		"eq": "=", "ne": "!=", "gt": ">", "ge": ">=", "lt": "<", "le": "<=",
+	}[op]
+	if !ok {
+		return "", nil, fmt.Errorf("unknown comparison operator: %q", op)
+	}
+
+	p.skipSpaces()
+	return p.buildComparison(field, sqlOp)
+}
+
+func (p *filterParser) buildComparison(field, sqlOp string) (string, []interface{}, error) {
+	if p.pos >= len(p.input) {
+		return "", nil, fmt.Errorf("expected value at position %d", p.pos)
+	}
+	fieldExpr := jsonExtract(field)
+	rest := strings.ToLower(p.input[p.pos:])
+
+	// null
+	if strings.HasPrefix(rest, "null") && !isIdentRune(rune(p.peek(4))) {
+		p.pos += 4
+		if sqlOp == "=" {
+			return fieldExpr + " IS NULL", nil, nil
+		}
+		return fieldExpr + " IS NOT NULL", nil, nil
+	}
+	// true
+	if strings.HasPrefix(rest, "true") && !isIdentRune(rune(p.peek(4))) {
+		p.pos += 4
+		return fieldExpr + " " + sqlOp + " ?", []interface{}{true}, nil
+	}
+	// false
+	if strings.HasPrefix(rest, "false") && !isIdentRune(rune(p.peek(5))) {
+		p.pos += 5
+		return fieldExpr + " " + sqlOp + " ?", []interface{}{false}, nil
+	}
+	// string literal
+	if p.input[p.pos] == '\'' {
+		s, err := p.parseStringLiteral()
+		if err != nil {
+			return "", nil, err
+		}
+		return fieldExpr + " " + sqlOp + " ?", []interface{}{s}, nil
+	}
+	// number
+	return p.parseNumber(fieldExpr, sqlOp)
+}
+
+// peek returns the rune at pos+offset, or 0 if out of range.
+func (p *filterParser) peek(offset int) byte {
+	i := p.pos + offset
+	if i >= len(p.input) {
+		return 0
+	}
+	return p.input[i]
+}
+
+func (p *filterParser) parseNumber(fieldExpr, sqlOp string) (string, []interface{}, error) {
+	start := p.pos
+	if p.pos < len(p.input) && p.input[p.pos] == '-' {
+		p.pos++
+	}
+	for p.pos < len(p.input) && (unicode.IsDigit(rune(p.input[p.pos])) || p.input[p.pos] == '.') {
+		p.pos++
+	}
+	numStr := p.input[start:p.pos]
+	if numStr == "" || numStr == "-" {
+		return "", nil, fmt.Errorf("expected numeric value at position %d", start)
+	}
+	if strings.Contains(numStr, ".") {
+		f, err := strconv.ParseFloat(numStr, 64)
+		if err != nil {
+			return "", nil, fmt.Errorf("invalid number %q: %w", numStr, err)
+		}
+		return fieldExpr + " " + sqlOp + " ?", []interface{}{f}, nil
+	}
+	n, err := strconv.ParseInt(numStr, 10, 64)
+	if err != nil {
+		return "", nil, fmt.Errorf("invalid number %q: %w", numStr, err)
+	}
+	return fieldExpr + " " + sqlOp + " ?", []interface{}{n}, nil
+}
+
+// parseSearchIn handles: search.in(field, 'val1,val2' [, 'delimiter'])
+func (p *filterParser) parseSearchIn() (string, []interface{}, error) {
+	p.skipSpaces()
+	p.pos += len("search.in(")
+
+	field, err := p.parseIdentifier()
+	if err != nil {
+		return "", nil, fmt.Errorf("search.in: %w", err)
+	}
+	if err := p.expectComma("search.in"); err != nil {
+		return "", nil, err
+	}
+
+	valList, err := p.parseStringLiteral()
+	if err != nil {
+		return "", nil, fmt.Errorf("search.in values: %w", err)
+	}
+
+	delimiter := ","
+	p.skipSpaces()
+	if p.pos < len(p.input) && p.input[p.pos] == ',' {
+		p.pos++
+		d, err := p.parseStringLiteral()
+		if err != nil {
+			return "", nil, fmt.Errorf("search.in delimiter: %w", err)
+		}
+		if d != "" {
+			delimiter = d
+		}
+	}
+
+	if err := p.expectCloseParen("search.in"); err != nil {
+		return "", nil, err
+	}
+
+	values := strings.Split(valList, delimiter)
+	fieldExpr := jsonExtract(field)
+	placeholders := make([]string, len(values))
+	args := make([]interface{}, len(values))
+	for i, v := range values {
+		placeholders[i] = "?"
+		args[i] = strings.TrimSpace(v)
+	}
+	return fieldExpr + " IN (" + strings.Join(placeholders, ",") + ")", args, nil
+}
+
+// parseStartsWith handles: startswith(field, 'prefix')
+func (p *filterParser) parseStartsWith() (string, []interface{}, error) {
+	p.skipSpaces()
+	p.pos += len("startswith(")
+
+	field, err := p.parseIdentifier()
+	if err != nil {
+		return "", nil, fmt.Errorf("startswith: %w", err)
+	}
+	if err := p.expectComma("startswith"); err != nil {
+		return "", nil, err
+	}
+
+	prefix, err := p.parseStringLiteral()
+	if err != nil {
+		return "", nil, fmt.Errorf("startswith: %w", err)
+	}
+
+	if err := p.expectCloseParen("startswith"); err != nil {
+		return "", nil, err
+	}
+
+	fieldExpr := jsonExtract(field)
+	// Escape LIKE metacharacters in prefix.
+	escaped := strings.ReplaceAll(prefix, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, "%", `\%`)
+	escaped = strings.ReplaceAll(escaped, "_", `\_`)
+	return fieldExpr + ` LIKE ? ESCAPE '\'`, []interface{}{escaped + "%"}, nil
+}
+
+func (p *filterParser) expectComma(ctx string) error {
+	p.skipSpaces()
+	if p.pos >= len(p.input) || p.input[p.pos] != ',' {
+		return fmt.Errorf("%s: expected ','", ctx)
+	}
+	p.pos++
+	return nil
+}
+
+func (p *filterParser) expectCloseParen(ctx string) error {
+	p.skipSpaces()
+	if p.pos >= len(p.input) || p.input[p.pos] != ')' {
+		return fmt.Errorf("%s: expected ')'", ctx)
+	}
+	p.pos++
+	return nil
+}

--- a/internal/application/odata_filter_test.go
+++ b/internal/application/odata_filter_test.go
@@ -1,0 +1,312 @@
+package application
+
+import (
+	"strings"
+	"testing"
+)
+
+// --- ParseODataFilter ---
+
+func TestParseODataFilter_SimpleEq(t *testing.T) {
+	t.Parallel()
+	sql, args, err := ParseODataFilter("Category eq 'Hotel'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "json_extract(content, '$.Category')") {
+		t.Errorf("expected json_extract for Category, got: %s", sql)
+	}
+	if !strings.Contains(sql, "= ?") {
+		t.Errorf("expected = ?, got: %s", sql)
+	}
+	if len(args) != 1 || args[0] != "Hotel" {
+		t.Errorf("expected args=[Hotel], got %v", args)
+	}
+}
+
+func TestParseODataFilter_Ne(t *testing.T) {
+	t.Parallel()
+	sql, args, err := ParseODataFilter("Status ne 'deleted'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "!= ?") {
+		t.Errorf("expected != ?, got: %s", sql)
+	}
+	if args[0] != "deleted" {
+		t.Errorf("expected args=[deleted], got %v", args)
+	}
+}
+
+func TestParseODataFilter_NumericGe(t *testing.T) {
+	t.Parallel()
+	sql, args, err := ParseODataFilter("Rating ge 4")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, ">= ?") {
+		t.Errorf("expected >= ?, got: %s", sql)
+	}
+	if args[0] != int64(4) {
+		t.Errorf("expected args=[4], got %v (%T)", args[0], args[0])
+	}
+}
+
+func TestParseODataFilter_FloatLt(t *testing.T) {
+	t.Parallel()
+	sql, args, err := ParseODataFilter("Price lt 9.99")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "< ?") {
+		t.Errorf("expected < ?, got: %s", sql)
+	}
+	if args[0] != 9.99 {
+		t.Errorf("expected args=[9.99], got %v", args[0])
+	}
+}
+
+func TestParseODataFilter_EqNull(t *testing.T) {
+	t.Parallel()
+	sql, args, err := ParseODataFilter("Field eq null")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "IS NULL") {
+		t.Errorf("expected IS NULL, got: %s", sql)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args, got %v", args)
+	}
+}
+
+func TestParseODataFilter_NeNull(t *testing.T) {
+	t.Parallel()
+	sql, args, err := ParseODataFilter("Field ne null")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "IS NOT NULL") {
+		t.Errorf("expected IS NOT NULL, got: %s", sql)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args, got %v", args)
+	}
+}
+
+func TestParseODataFilter_BoolTrue(t *testing.T) {
+	t.Parallel()
+	sql, args, err := ParseODataFilter("Active eq true")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "= ?") {
+		t.Errorf("expected = ?, got: %s", sql)
+	}
+	if args[0] != true {
+		t.Errorf("expected args=[true], got %v", args[0])
+	}
+}
+
+func TestParseODataFilter_And(t *testing.T) {
+	t.Parallel()
+	sql, args, err := ParseODataFilter("Category eq 'Hotel' and Rating ge 4")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, " AND ") {
+		t.Errorf("expected AND, got: %s", sql)
+	}
+	if len(args) != 2 {
+		t.Errorf("expected 2 args, got %d", len(args))
+	}
+}
+
+func TestParseODataFilter_Or(t *testing.T) {
+	t.Parallel()
+	sql, args, err := ParseODataFilter("Category eq 'Hotel' or Category eq 'Motel'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, " OR ") {
+		t.Errorf("expected OR, got: %s", sql)
+	}
+	if len(args) != 2 {
+		t.Errorf("expected 2 args, got %d", len(args))
+	}
+}
+
+func TestParseODataFilter_Not(t *testing.T) {
+	t.Parallel()
+	sql, _, err := ParseODataFilter("not Category eq 'Hotel'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(sql, "NOT (") {
+		t.Errorf("expected NOT (...), got: %s", sql)
+	}
+}
+
+func TestParseODataFilter_Parentheses(t *testing.T) {
+	t.Parallel()
+	sql, args, err := ParseODataFilter("(Category eq 'Hotel' or Category eq 'Motel') and Rating ge 3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, " AND ") {
+		t.Errorf("expected AND, got: %s", sql)
+	}
+	if len(args) != 3 {
+		t.Errorf("expected 3 args, got %d: %v", len(args), args)
+	}
+}
+
+func TestParseODataFilter_SearchIn(t *testing.T) {
+	t.Parallel()
+	sql, args, err := ParseODataFilter("search.in(Category, 'Hotel,Motel')")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "IN (") {
+		t.Errorf("expected IN (...), got: %s", sql)
+	}
+	if len(args) != 2 {
+		t.Errorf("expected 2 args, got %d: %v", len(args), args)
+	}
+	if args[0] != "Hotel" || args[1] != "Motel" {
+		t.Errorf("expected [Hotel Motel], got %v", args)
+	}
+}
+
+func TestParseODataFilter_SearchIn_CustomDelimiter(t *testing.T) {
+	t.Parallel()
+	sql, args, err := ParseODataFilter("search.in(Category, 'Hotel|Motel', '|')")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "IN (") {
+		t.Errorf("expected IN (...), got: %s", sql)
+	}
+	if len(args) != 2 || args[0] != "Hotel" || args[1] != "Motel" {
+		t.Errorf("expected [Hotel Motel], got %v", args)
+	}
+}
+
+func TestParseODataFilter_StartsWith(t *testing.T) {
+	t.Parallel()
+	sql, args, err := ParseODataFilter("startswith(Name, 'Sea')")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "LIKE ?") {
+		t.Errorf("expected LIKE ?, got: %s", sql)
+	}
+	if len(args) != 1 || args[0] != "Sea%" {
+		t.Errorf("expected args=[Sea%%], got %v", args)
+	}
+}
+
+func TestParseODataFilter_StartsWith_EscapesMetachars(t *testing.T) {
+	t.Parallel()
+	_, args, err := ParseODataFilter("startswith(Name, '50%Off')")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// % in the prefix must be escaped so LIKE doesn't treat it as wildcard.
+	if args[0] != `50\%Off%` {
+		t.Errorf("expected escaped prefix, got %q", args[0])
+	}
+}
+
+func TestParseODataFilter_SingleQuoteEscape(t *testing.T) {
+	t.Parallel()
+	_, args, err := ParseODataFilter("Name eq 'O''Brien'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if args[0] != "O'Brien" {
+		t.Errorf("expected O'Brien, got %v", args[0])
+	}
+}
+
+func TestParseODataFilter_UnknownOperator(t *testing.T) {
+	t.Parallel()
+	_, _, err := ParseODataFilter("Field xyz 'value'")
+	if err == nil {
+		t.Fatal("expected error for unknown operator")
+	}
+}
+
+func TestParseODataFilter_EmptyString(t *testing.T) {
+	t.Parallel()
+	sql, args, err := ParseODataFilter("")
+	// Empty filter is technically an error (no expression).
+	if err == nil {
+		t.Logf("empty filter returned sql=%q args=%v — acceptable only if caller guards empty input", sql, args)
+	}
+}
+
+func TestParseODataFilter_TrailingGarbage(t *testing.T) {
+	t.Parallel()
+	_, _, err := ParseODataFilter("Field eq 'val' JUNK")
+	if err == nil {
+		t.Fatal("expected error for trailing garbage")
+	}
+}
+
+// --- ParseODataOrderBy ---
+
+func TestParseODataOrderBy_SingleAsc(t *testing.T) {
+	t.Parallel()
+	sql, err := ParseODataOrderBy("Rating asc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "json_extract(content, '$.Rating') ASC") {
+		t.Errorf("unexpected orderby sql: %s", sql)
+	}
+}
+
+func TestParseODataOrderBy_SingleDesc(t *testing.T) {
+	t.Parallel()
+	sql, err := ParseODataOrderBy("Rating desc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "json_extract(content, '$.Rating') DESC") {
+		t.Errorf("unexpected orderby sql: %s", sql)
+	}
+}
+
+func TestParseODataOrderBy_DefaultAsc(t *testing.T) {
+	t.Parallel()
+	sql, err := ParseODataOrderBy("Rating")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "ASC") {
+		t.Errorf("expected default ASC, got: %s", sql)
+	}
+}
+
+func TestParseODataOrderBy_MultipleFields(t *testing.T) {
+	t.Parallel()
+	sql, err := ParseODataOrderBy("Rating desc, Name asc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "$.Rating") || !strings.Contains(sql, "DESC") {
+		t.Errorf("expected Rating DESC in orderby sql: %s", sql)
+	}
+	if !strings.Contains(sql, "$.Name") || !strings.Contains(sql, "ASC") {
+		t.Errorf("expected Name ASC in orderby sql: %s", sql)
+	}
+}
+
+func TestParseODataOrderBy_InvalidDirection(t *testing.T) {
+	t.Parallel()
+	_, err := ParseODataOrderBy("Rating sideways")
+	if err == nil {
+		t.Fatal("expected error for invalid sort direction")
+	}
+}

--- a/internal/application/search_params.go
+++ b/internal/application/search_params.go
@@ -1,0 +1,21 @@
+package application
+
+// SearchParams holds all OData query parameters for a search request.
+type SearchParams struct {
+	Search       string
+	Filter       string   // $filter
+	OrderBy      string   // $orderby
+	Select       []string // $select (empty = all fields)
+	SearchFields []string // searchFields (empty = all fields)
+	Top          int      // $top  (0 = use default)
+	Skip         int      // $skip
+	IncludeCount bool     // $count
+}
+
+// SearchResult is returned by DocumentService.SearchDocuments.
+type SearchResult struct {
+	Value []map[string]interface{}
+	Total int64 // total matching docs before TOP/SKIP
+}
+
+const defaultTop = 50

--- a/internal/domain/document.go
+++ b/internal/domain/document.go
@@ -11,10 +11,25 @@ type Document struct {
 	Content   string // JSON文字列で保持
 }
 
+// SearchOptions is passed to DocumentRepository.Search to specify query constraints.
+// WhereSQL and WhereArgs are compiled from an OData $filter expression using
+// json_extract() for SQLite. TextSearch is applied separately (LIKE on full content).
+type SearchOptions struct {
+	TextSearch       string        // raw search text; "" or "*" means no text filter
+	TextSearchFields []string      // restrict text search to these fields; empty = full content
+	WhereSQL         string        // compiled OData $filter SQL fragment (no WHERE keyword)
+	WhereArgs        []interface{} // bind args for WhereSQL
+	OrderSQL         string        // compiled OData $orderby SQL fragment (no ORDER BY keyword)
+	Top              int           // must be > 0 (caller is responsible for applying the default)
+	Skip             int
+}
+
 type DocumentRepository interface {
 	Upsert(doc *Document) error
 	Find(indexName, key string) (*Document, error)
 	Delete(indexName, key string) error
 	List(indexName string) ([]*Document, error)
 	Count(indexName string) (int, error)
+	// Search returns paginated documents matching opts and the total count before paging.
+	Search(indexName string, opts SearchOptions) ([]*Document, int64, error)
 }

--- a/internal/infrastructure/sqlite_document_repository.go
+++ b/internal/infrastructure/sqlite_document_repository.go
@@ -3,6 +3,8 @@ package infrastructure
 import (
 	"ai-search-emulator/internal/domain"
 	"database/sql"
+	"fmt"
+	"strings"
 )
 
 type SQLiteDocumentRepository struct {
@@ -53,4 +55,70 @@ func (r *SQLiteDocumentRepository) Count(indexName string) (int, error) {
 	var count int
 	err := r.db.QueryRow("SELECT COUNT(*) FROM documents WHERE index_name = ?", indexName).Scan(&count)
 	return count, err
+}
+
+// Search executes a filtered, ordered, paginated query against the documents table.
+// Total count is computed before paging so the caller can include it in $count responses.
+func (r *SQLiteDocumentRepository) Search(indexName string, opts domain.SearchOptions) ([]*domain.Document, int64, error) {
+	where, args := r.buildWhere(indexName, opts)
+
+	var total int64
+	countSQL := "SELECT COUNT(*) FROM documents WHERE " + where
+	if err := r.db.QueryRow(countSQL, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("search count: %w", err)
+	}
+
+	mainSQL := "SELECT index_name, key, content FROM documents WHERE " + where
+	if opts.OrderSQL != "" {
+		mainSQL += " ORDER BY " + opts.OrderSQL
+	}
+	top := opts.Top
+	if top <= 0 {
+		top = 50
+	}
+	mainSQL += fmt.Sprintf(" LIMIT %d OFFSET %d", top, opts.Skip)
+
+	rows, err := r.db.Query(mainSQL, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("search query: %w", err)
+	}
+	defer rows.Close()
+
+	var result []*domain.Document
+	for rows.Next() {
+		var doc domain.Document
+		if err := rows.Scan(&doc.IndexName, &doc.Key, &doc.Content); err != nil {
+			return nil, 0, err
+		}
+		result = append(result, &doc)
+	}
+	return result, total, rows.Err()
+}
+
+// buildWhere constructs the WHERE clause and bind args for Search.
+func (r *SQLiteDocumentRepository) buildWhere(indexName string, opts domain.SearchOptions) (string, []interface{}) {
+	parts := []string{"index_name = ?"}
+	args := []interface{}{indexName}
+
+	if opts.TextSearch != "" && opts.TextSearch != "*" {
+		lower := strings.ToLower(opts.TextSearch)
+		if len(opts.TextSearchFields) > 0 {
+			fieldParts := make([]string, len(opts.TextSearchFields))
+			for i, f := range opts.TextSearchFields {
+				fieldParts[i] = fmt.Sprintf("LOWER(json_extract(content, '$.%s')) LIKE ?", f)
+				args = append(args, "%"+lower+"%")
+			}
+			parts = append(parts, "("+strings.Join(fieldParts, " OR ")+")")
+		} else {
+			parts = append(parts, "LOWER(content) LIKE ?")
+			args = append(args, "%"+lower+"%")
+		}
+	}
+
+	if opts.WhereSQL != "" {
+		parts = append(parts, "("+opts.WhereSQL+")")
+		args = append(args, opts.WhereArgs...)
+	}
+
+	return strings.Join(parts, " AND "), args
 }

--- a/internal/infrastructure/sqlite_document_repository_test.go
+++ b/internal/infrastructure/sqlite_document_repository_test.go
@@ -2,6 +2,7 @@ package infrastructure
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"ai-search-emulator/internal/domain"
@@ -166,5 +167,179 @@ func TestSQLiteDocumentRepository_OperationsOnClosedDB(t *testing.T) {
 	}
 	if _, err := repo.Count("x"); err == nil {
 		t.Errorf("expected error on closed db (Count)")
+	}
+}
+
+// --- Search ---
+
+func TestSQLiteDocumentRepository_Search_NoFilter(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	idxRepo := NewSQLiteIndexRepository(db)
+	seedTestIndex(t, idxRepo, "idx")
+	repo := NewSQLiteDocumentRepository(db)
+
+	for i := 1; i <= 3; i++ {
+		_ = repo.Upsert(&domain.Document{
+			IndexName: "idx", Key: fmt.Sprintf("%d", i),
+			Content: fmt.Sprintf(`{"id":"%d","title":"doc%d"}`, i, i),
+		})
+	}
+
+	docs, total, err := repo.Search("idx", domain.SearchOptions{Top: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	if len(docs) != 3 {
+		t.Errorf("len(docs) = %d, want 3", len(docs))
+	}
+}
+
+func TestSQLiteDocumentRepository_Search_TextSearch(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	idxRepo := NewSQLiteIndexRepository(db)
+	seedTestIndex(t, idxRepo, "idx")
+	repo := NewSQLiteDocumentRepository(db)
+
+	_ = repo.Upsert(&domain.Document{IndexName: "idx", Key: "1", Content: `{"id":"1","title":"Alpha Hotel"}`})
+	_ = repo.Upsert(&domain.Document{IndexName: "idx", Key: "2", Content: `{"id":"2","title":"Beta Motel"}`})
+
+	docs, total, err := repo.Search("idx", domain.SearchOptions{TextSearch: "HOTEL", Top: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+	if len(docs) != 1 || docs[0].Key != "1" {
+		t.Errorf("unexpected result: %v", docs)
+	}
+}
+
+func TestSQLiteDocumentRepository_Search_TextSearchFields(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	idxRepo := NewSQLiteIndexRepository(db)
+	seedTestIndex(t, idxRepo, "idx")
+	repo := NewSQLiteDocumentRepository(db)
+
+	_ = repo.Upsert(&domain.Document{IndexName: "idx", Key: "1", Content: `{"id":"1","title":"Alpha","notes":"Hotel nearby"}`})
+	_ = repo.Upsert(&domain.Document{IndexName: "idx", Key: "2", Content: `{"id":"2","title":"Hotel","notes":"nothing"}`})
+
+	// Search only in 'title' field — doc 1 has "Alpha" in title, not "hotel".
+	// doc 2 has "Hotel" in title.
+	docs, total, err := repo.Search("idx", domain.SearchOptions{
+		TextSearch:       "hotel",
+		TextSearchFields: []string{"title"},
+		Top:              10,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 1 || docs[0].Key != "2" {
+		t.Errorf("expected only doc2, got total=%d docs=%v", total, docs)
+	}
+}
+
+func TestSQLiteDocumentRepository_Search_ODataFilter(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	idxRepo := NewSQLiteIndexRepository(db)
+	seedTestIndex(t, idxRepo, "idx")
+	repo := NewSQLiteDocumentRepository(db)
+
+	_ = repo.Upsert(&domain.Document{IndexName: "idx", Key: "1", Content: `{"id":"1","Category":"Hotel","Rating":5}`})
+	_ = repo.Upsert(&domain.Document{IndexName: "idx", Key: "2", Content: `{"id":"2","Category":"Motel","Rating":3}`})
+	_ = repo.Upsert(&domain.Document{IndexName: "idx", Key: "3", Content: `{"id":"3","Category":"Hotel","Rating":2}`})
+
+	docs, total, err := repo.Search("idx", domain.SearchOptions{
+		WhereSQL:  "json_extract(content, '$.Category') = ? AND json_extract(content, '$.Rating') >= ?",
+		WhereArgs: []interface{}{"Hotel", int64(4)},
+		Top:       10,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 1 || docs[0].Key != "1" {
+		t.Errorf("expected doc1, got total=%d docs=%v", total, docs)
+	}
+}
+
+func TestSQLiteDocumentRepository_Search_TopSkip(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	idxRepo := NewSQLiteIndexRepository(db)
+	seedTestIndex(t, idxRepo, "idx")
+	repo := NewSQLiteDocumentRepository(db)
+
+	for i := 1; i <= 5; i++ {
+		_ = repo.Upsert(&domain.Document{
+			IndexName: "idx", Key: fmt.Sprintf("%d", i),
+			Content: fmt.Sprintf(`{"id":"%d"}`, i),
+		})
+	}
+
+	docs, total, err := repo.Search("idx", domain.SearchOptions{Top: 2, Skip: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 5 {
+		t.Errorf("total = %d, want 5", total)
+	}
+	if len(docs) != 2 {
+		t.Errorf("len(docs) = %d, want 2", len(docs))
+	}
+}
+
+func TestSQLiteDocumentRepository_Search_DefaultTop(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	idxRepo := NewSQLiteIndexRepository(db)
+	seedTestIndex(t, idxRepo, "idx")
+	repo := NewSQLiteDocumentRepository(db)
+
+	for i := 1; i <= 60; i++ {
+		_ = repo.Upsert(&domain.Document{
+			IndexName: "idx", Key: fmt.Sprintf("%d", i),
+			Content: fmt.Sprintf(`{"id":"%d"}`, i),
+		})
+	}
+
+	docs, total, err := repo.Search("idx", domain.SearchOptions{Top: 0}) // 0 = use default (50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 60 {
+		t.Errorf("total = %d, want 60", total)
+	}
+	if len(docs) != 50 {
+		t.Errorf("len(docs) = %d, want 50 (default top)", len(docs))
+	}
+}
+
+func TestSQLiteDocumentRepository_Search_OrderBy(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	idxRepo := NewSQLiteIndexRepository(db)
+	seedTestIndex(t, idxRepo, "idx")
+	repo := NewSQLiteDocumentRepository(db)
+
+	_ = repo.Upsert(&domain.Document{IndexName: "idx", Key: "a", Content: `{"id":"a","Rating":1}`})
+	_ = repo.Upsert(&domain.Document{IndexName: "idx", Key: "b", Content: `{"id":"b","Rating":3}`})
+	_ = repo.Upsert(&domain.Document{IndexName: "idx", Key: "c", Content: `{"id":"c","Rating":2}`})
+
+	docs, _, err := repo.Search("idx", domain.SearchOptions{
+		OrderSQL: "json_extract(content, '$.Rating') DESC",
+		Top:      10,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) != 3 || docs[0].Key != "b" || docs[2].Key != "a" {
+		t.Errorf("unexpected order: %v", docs)
 	}
 }


### PR DESCRIPTION
## Summary

- `$top` / `$skip` — SQL LIMIT/OFFSET で実装（デフォルト上限 50）
- `$orderby` — `json_extract` を使った SQL ORDER BY に変換
- `$filter` — 再帰下降パーサーで OData 式を SQLite WHERE 句に変換
  - 比較演算子: `eq`, `ne`, `gt`, `ge`, `lt`, `le`
  - 論理演算子: `and`, `or`, `not`
  - 関数: `search.in()`, `startswith()`
  - null チェック: `field eq null` → `IS NULL`
- `$select` — フェッチ後に Go 側でフィールドを絞り込み
- `$count` — ページング前の総件数を `@odata.count` としてレスポンスに含む
- `searchFields` — テキスト検索対象フィールドを絞り込み

## Architecture

- `internal/application/odata_filter.go` — OData パーサー（新規）
- `internal/domain/document.go` — `SearchOptions` 追加、`DocumentRepository` に `Search` メソッド追加
- `internal/infrastructure/sqlite_document_repository.go` — `Search` 実装
- `internal/application/document_service.go` — `SearchDocuments` を `SearchParams` 対応に更新
- `internal/api/handler.go` — GET/POST 両エンドポイントで OData パラメータ解析

## Test plan

- [ ] OData パーサー単体テスト（`odata_filter_test.go`）
- [ ] SQLite Search 統合テスト（`sqlite_document_repository_test.go`）
- [ ] DocumentService 単体テスト（mock 経由）
- [ ] `mise exec -- go test -race ./...` が全 PASS することを確認
- [ ] カバレッジ: application 85.7%、infrastructure 93.2%

Closes #7