### PR TITLE
feat: add OData metadata fields to responses (#8)

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -6,9 +6,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -80,7 +82,10 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{"value": indexes})
+		c.JSON(http.StatusOK, gin.H{
+			"@odata.context": requestBaseURL(c.Request) + "/$metadata#indexes",
+			"value":          indexes,
+		})
 	})
 	// インデックス取得API
 	r.GET("/indexes/:index", func(c *gin.Context) {
@@ -221,7 +226,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			handleSearchError(c, err)
 			return
 		}
-		respondSearch(c, result, params.IncludeCount)
+		respondSearch(c, indexName, params, result)
 	})
 	// ドキュメント検索API (POST)
 	r.POST("/indexes/:index/docs/search", func(c *gin.Context) {
@@ -236,7 +241,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			handleSearchError(c, err)
 			return
 		}
-		respondSearch(c, result, params.IncludeCount)
+		respondSearch(c, indexName, params, result)
 	})
 }
 
@@ -347,10 +352,81 @@ func handleSearchError(c *gin.Context, err error) {
 	c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
 }
 
-func respondSearch(c *gin.Context, result *application.SearchResult, includeCount bool) {
-	resp := gin.H{"value": result.Value}
-	if includeCount {
+func requestBaseURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https") {
+		scheme = "https"
+	}
+	host := r.Host
+	if h := r.Header.Get("X-Forwarded-Host"); h != "" {
+		host = h
+	}
+	return scheme + "://" + host
+}
+
+func buildNextLink(baseURL, indexName string, params application.SearchParams, total int64) string {
+	top := params.Top
+	if top <= 0 {
+		top = application.DefaultTop
+	}
+	nextSkip := params.Skip + top
+	if int64(nextSkip) >= total {
+		return ""
+	}
+	u, _ := url.Parse(baseURL + "/indexes/" + url.PathEscape(indexName) + "/docs")
+	q := url.Values{}
+	if params.Search != "" {
+		q.Set("search", params.Search)
+	}
+	if params.Filter != "" {
+		q.Set("$filter", params.Filter)
+	}
+	if params.OrderBy != "" {
+		q.Set("$orderby", params.OrderBy)
+	}
+	if len(params.Select) > 0 {
+		q.Set("$select", strings.Join(params.Select, ","))
+	}
+	if len(params.SearchFields) > 0 {
+		q.Set("searchFields", strings.Join(params.SearchFields, ","))
+	}
+	if params.Top > 0 {
+		q.Set("$top", strconv.Itoa(params.Top))
+	}
+	q.Set("$skip", strconv.Itoa(nextSkip))
+	if params.IncludeCount {
+		q.Set("$count", "true")
+	}
+	// url.Values.Encode percent-encodes "$" as "%24"; Azure nextLink URLs
+	// conventionally use the literal "$" which is a valid query char.
+	u.RawQuery = strings.ReplaceAll(q.Encode(), "%24", "$")
+	return u.String()
+}
+
+func respondSearch(c *gin.Context, indexName string, params application.SearchParams, result *application.SearchResult) {
+	baseURL := requestBaseURL(c.Request)
+	odataCtx := fmt.Sprintf("%s/indexes('%s')/$metadata#docs(*)", baseURL, indexName)
+
+	docs := make([]map[string]interface{}, len(result.Value))
+	for i, doc := range result.Value {
+		d := make(map[string]interface{}, len(doc)+1)
+		for k, v := range doc {
+			d[k] = v
+		}
+		d["@search.score"] = 1.0
+		docs[i] = d
+	}
+
+	resp := gin.H{
+		"@odata.context":   odataCtx,
+		"@search.coverage": 100.0,
+		"value":            docs,
+	}
+	if params.IncludeCount {
 		resp["@odata.count"] = result.Total
+	}
+	if nextLink := buildNextLink(baseURL, indexName, params, result.Total); nextLink != "" {
+		resp["@odata.nextLink"] = nextLink
 	}
 	c.JSON(http.StatusOK, resp)
 }

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -717,6 +718,127 @@ func TestCreateIndex_EchoesRequestBody(t *testing.T) {
 	// Body should be the original schema (compact comparison via field).
 	if !bytes.Contains(rec.Body.Bytes(), []byte(`"name": "movies"`)) {
 		t.Errorf("response body should echo input, got %s", rec.Body.String())
+	}
+}
+
+// --- OData metadata ---
+
+func TestListIndexes_ODataContext(t *testing.T) {
+	r := setupRouter(t)
+	doRequest(t, r, http.MethodPost, "/indexes", apiTestSchema)
+
+	rec := doRequest(t, r, http.MethodGet, "/indexes", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var body map[string]interface{}
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	ctx, ok := body["@odata.context"].(string)
+	if !ok || ctx == "" {
+		t.Fatalf("@odata.context missing or empty, body=%s", rec.Body.String())
+	}
+	if !strings.HasSuffix(ctx, "/$metadata#indexes") {
+		t.Errorf("@odata.context = %q, want suffix '/$metadata#indexes'", ctx)
+	}
+}
+
+func TestSearchDocuments_GET_ODataMetadata(t *testing.T) {
+	r := setupRouter(t)
+	doRequest(t, r, http.MethodPost, "/indexes", apiTestSchema)
+	doRequest(t, r, http.MethodPost, "/indexes/movies/docs", `{"id":"1","title":"alpha"}`)
+
+	rec := doRequest(t, r, http.MethodGet, "/indexes/movies/docs?search=alpha", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var body map[string]interface{}
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+
+	ctx, ok := body["@odata.context"].(string)
+	if !ok || ctx == "" {
+		t.Fatalf("@odata.context missing, body=%s", rec.Body.String())
+	}
+	if !strings.Contains(ctx, "/indexes('movies')/$metadata#docs(*)") {
+		t.Errorf("@odata.context = %q, want suffix containing \"/indexes('movies')/$metadata#docs(*)\"", ctx)
+	}
+
+	coverage, ok := body["@search.coverage"].(float64)
+	if !ok || coverage != 100.0 {
+		t.Errorf("@search.coverage = %v, want 100.0", body["@search.coverage"])
+	}
+
+	docs, _ := body["value"].([]interface{})
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doc, got %d", len(docs))
+	}
+	doc := docs[0].(map[string]interface{})
+	score, ok := doc["@search.score"].(float64)
+	if !ok || score != 1.0 {
+		t.Errorf("@search.score = %v, want 1.0", doc["@search.score"])
+	}
+}
+
+func TestSearchDocuments_GET_ODataCount(t *testing.T) {
+	r := setupRouter(t)
+	doRequest(t, r, http.MethodPost, "/indexes", apiTestSchema)
+	doRequest(t, r, http.MethodPost, "/indexes/movies/docs", `{"id":"1","title":"alpha"}`)
+	doRequest(t, r, http.MethodPost, "/indexes/movies/docs", `{"id":"2","title":"beta"}`)
+
+	rec := doRequest(t, r, http.MethodGet, "/indexes/movies/docs?$count=true", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var body map[string]interface{}
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+
+	count, ok := body["@odata.count"].(float64)
+	if !ok || int(count) != 2 {
+		t.Errorf("@odata.count = %v, want 2", body["@odata.count"])
+	}
+}
+
+func TestSearchDocuments_GET_NextLink(t *testing.T) {
+	r := setupRouter(t)
+	doRequest(t, r, http.MethodPost, "/indexes", apiTestSchema)
+	for i := 1; i <= 5; i++ {
+		doRequest(t, r, http.MethodPost, "/indexes/movies/docs",
+			fmt.Sprintf(`{"id":"%d","title":"doc%d"}`, i, i))
+	}
+
+	rec := doRequest(t, r, http.MethodGet, "/indexes/movies/docs?$top=2&$skip=0", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var body map[string]interface{}
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+
+	nextLink, ok := body["@odata.nextLink"].(string)
+	if !ok || nextLink == "" {
+		t.Fatalf("@odata.nextLink missing, body=%s", rec.Body.String())
+	}
+	if !strings.Contains(nextLink, "$skip=2") {
+		t.Errorf("@odata.nextLink = %q, expected $skip=2", nextLink)
+	}
+	if !strings.Contains(nextLink, "$top=2") {
+		t.Errorf("@odata.nextLink = %q, expected $top=2", nextLink)
+	}
+}
+
+func TestSearchDocuments_GET_NoNextLinkOnLastPage(t *testing.T) {
+	r := setupRouter(t)
+	doRequest(t, r, http.MethodPost, "/indexes", apiTestSchema)
+	doRequest(t, r, http.MethodPost, "/indexes/movies/docs", `{"id":"1","title":"a"}`)
+	doRequest(t, r, http.MethodPost, "/indexes/movies/docs", `{"id":"2","title":"b"}`)
+
+	rec := doRequest(t, r, http.MethodGet, "/indexes/movies/docs?$top=10", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var body map[string]interface{}
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+
+	if _, ok := body["@odata.nextLink"]; ok {
+		t.Errorf("@odata.nextLink should be absent when all docs fit on one page, body=%s", rec.Body.String())
 	}
 }
 

--- a/internal/application/search_params.go
+++ b/internal/application/search_params.go
@@ -18,4 +18,8 @@ type SearchResult struct {
 	Total int64 // total matching docs before TOP/SKIP
 }
 
-const defaultTop = 50
+// DefaultTop is the page size used when $top is not specified.
+const DefaultTop = 50
+
+// unexported alias kept for internal use
+const defaultTop = DefaultTop


### PR DESCRIPTION
## Summary

- Adds `@odata.context` to `GET /indexes` responses (`…/$metadata#indexes`)
- Adds `@odata.context`, `@search.coverage`, `@search.score` (per doc), `@odata.count` (when `$count=true`), and `@odata.nextLink` (pagination) to search responses (GET and POST)
- Exports `DefaultTop` from the application package so the handler can compute the next-page skip offset
- `buildNextLink` preserves literal `$` in query parameter names to match Azure's convention

## Test plan

- [ ] `TestListIndexes_ODataContext` — `@odata.context` present with correct suffix on index list
- [ ] `TestSearchDocuments_GET_ODataMetadata` — `@odata.context`, `@search.coverage: 100.0`, `@search.score: 1.0` per doc
- [ ] `TestSearchDocuments_GET_ODataCount` — `@odata.count` present when `$count=true`
- [ ] `TestSearchDocuments_GET_NextLink` — `@odata.nextLink` with correct `$skip` and `$top`
- [ ] `TestSearchDocuments_GET_NoNextLinkOnLastPage` — `@odata.nextLink` absent when all results fit
- [ ] All existing tests continue to pass (`go test -race ./...`)