### PR TITLE
feat: implement Azure-compatible structured error responses (#9)

### DIFF
--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -45,6 +46,10 @@ func err409(c *gin.Context, message string) {
 	jsonErr(c, http.StatusConflict, "ResourceAlreadyExists", message)
 }
 
-func err500(c *gin.Context, message string) {
-	jsonErr(c, http.StatusInternalServerError, "InternalServerError", message)
+// err500 logs the internal error server-side and returns a generic message to
+// the client so that internal details (DB errors, stack traces, etc.) are
+// never exposed in the response body.
+func err500(c *gin.Context, err error) {
+	log.Printf("[ERROR] internal server error: %v", err)
+	jsonErr(c, http.StatusInternalServerError, "InternalServerError", "An internal server error occurred.")
 }

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func errResponse(code, message string) gin.H {
+	return gin.H{
+		"error": gin.H{
+			"code":    code,
+			"message": message,
+		},
+	}
+}
+
+func abortErr(c *gin.Context, status int, code, message string) {
+	c.AbortWithStatusJSON(status, errResponse(code, message))
+}
+
+func jsonErr(c *gin.Context, status int, code, message string) {
+	c.JSON(status, errResponse(code, message))
+}
+
+// Convenience wrappers for each HTTP status.
+
+func err400(c *gin.Context, message string) {
+	jsonErr(c, http.StatusBadRequest, "InvalidRequest", message)
+}
+
+func err400Missing(c *gin.Context, message string) {
+	jsonErr(c, http.StatusBadRequest, "MissingRequiredProperty", message)
+}
+
+func err401(c *gin.Context, message string) {
+	abortErr(c, http.StatusUnauthorized, "AuthenticationFailed", message)
+}
+
+func err404(c *gin.Context, message string) {
+	jsonErr(c, http.StatusNotFound, "ResourceNotFound", message)
+}
+
+func err409(c *gin.Context, message string) {
+	jsonErr(c, http.StatusConflict, "ResourceAlreadyExists", message)
+}
+
+func err500(c *gin.Context, message string) {
+	jsonErr(c, http.StatusInternalServerError, "InternalServerError", message)
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -29,7 +29,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 	r.POST("/indexes", func(c *gin.Context) {
 		body, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Failed to read request body"})
+			err400(c, "Failed to read request body")
 			return
 		}
 		var req struct {
@@ -39,15 +39,15 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			Analyzers  interface{} `json:"analyzers,omitempty"`
 		}
 		if err := json.Unmarshal(body, &req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+			err400(c, "Invalid request body")
 			return
 		}
 		err = app.IndexService.CreateIndex(c.Request.Context(), req.Name, io.NopCloser(bytes.NewReader(body)))
 		if err != nil {
 			if errors.Is(err, domain.ErrIndexAlreadyExists) {
-				c.JSON(http.StatusConflict, gin.H{"error": "Index already exists"})
+				err409(c, "Index already exists")
 			} else {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				err500(c, err.Error())
 			}
 			return
 		}
@@ -58,17 +58,17 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		indexName := c.Param("index")
 		var doc map[string]interface{}
 		if err := c.ShouldBindJSON(&doc); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid document body"})
+			err400(c, "Invalid document body")
 			return
 		}
 		err := app.DocumentService.AddOrUpdateSingleDoc(c.Request.Context(), indexName, doc)
 		if err != nil {
 			if errors.Is(err, domain.ErrIndexNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
+				err404(c, "Index not found")
 			} else if errors.Is(err, domain.ErrMissingKeyField) {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Document missing key field"})
+				err400Missing(c, "Document missing key field")
 			} else {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				err500(c, err.Error())
 			}
 			return
 		}
@@ -79,7 +79,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		selectFields := c.Query("$select")
 		indexes, err := app.IndexService.ListIndexes(c.Request.Context(), selectFields)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			err500(c, err.Error())
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{
@@ -93,9 +93,9 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		idx, err := app.IndexService.GetIndex(c.Request.Context(), indexName)
 		if err != nil {
 			if errors.Is(err, domain.ErrIndexNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
+				err404(c, "Index not found")
 			} else {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				err500(c, err.Error())
 			}
 			return
 		}
@@ -106,7 +106,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		indexName := c.Param("index")
 		body, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Failed to read request body"})
+			err400(c, "Failed to read request body")
 			return
 		}
 		var req struct {
@@ -116,12 +116,12 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			Analyzers  interface{} `json:"analyzers,omitempty"`
 		}
 		if err := json.Unmarshal(body, &req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+			err400(c, "Invalid request body")
 			return
 		}
 		created, err := app.IndexService.CreateOrUpdateIndex(c.Request.Context(), indexName, io.NopCloser(bytes.NewReader(body)))
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			err500(c, err.Error())
 			return
 		}
 		if created {
@@ -136,9 +136,9 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		err := app.IndexService.DeleteIndex(c.Request.Context(), indexName)
 		if err != nil {
 			if errors.Is(err, domain.ErrIndexNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
+				err404(c, "Index not found")
 			} else {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				err500(c, err.Error())
 			}
 			return
 		}
@@ -150,9 +150,9 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		stats, err := app.IndexService.GetIndexStats(c.Request.Context(), indexName)
 		if err != nil {
 			if errors.Is(err, domain.ErrIndexNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
+				err404(c, "Index not found")
 			} else {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				err500(c, err.Error())
 			}
 			return
 		}
@@ -165,15 +165,15 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			Value []map[string]interface{} `json:"value" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid batch request body"})
+			err400(c, "Invalid batch request body")
 			return
 		}
 		results, err := app.DocumentService.BatchOperation(c.Request.Context(), indexName, req.Value)
 		if err != nil {
 			if errors.Is(err, domain.ErrIndexNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
+				err404(c, "Index not found")
 			} else {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				err500(c, err.Error())
 			}
 			return
 		}
@@ -193,11 +193,11 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		doc, err := app.DocumentService.GetDocument(c.Request.Context(), indexName, key)
 		if err != nil {
 			if errors.Is(err, domain.ErrIndexNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
+				err404(c, "Index not found")
 			} else if errors.Is(err, domain.ErrDocumentNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "Document not found"})
+				err404(c, "Document not found")
 			} else {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				err500(c, err.Error())
 			}
 			return
 		}
@@ -209,9 +209,9 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		count, err := app.DocumentService.CountDocuments(c.Request.Context(), indexName)
 		if err != nil {
 			if errors.Is(err, domain.ErrIndexNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
+				err404(c, "Index not found")
 			} else {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				err500(c, err.Error())
 			}
 			return
 		}
@@ -233,7 +233,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		indexName := c.Param("index")
 		params, err := parseSearchParamsFromBody(c)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+			err400(c, "Invalid request body")
 			return
 		}
 		result, err := app.DocumentService.SearchDocuments(c.Request.Context(), indexName, params)
@@ -341,15 +341,15 @@ func parseSearchParamsFromBody(c *gin.Context) (application.SearchParams, error)
 
 func handleSearchError(c *gin.Context, err error) {
 	if errors.Is(err, domain.ErrIndexNotFound) {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Index not found"})
+		err404(c, "Index not found")
 		return
 	}
 	msg := err.Error()
 	if strings.HasPrefix(msg, "invalid $filter") || strings.HasPrefix(msg, "invalid $orderby") {
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		err400(c, msg)
 		return
 	}
-	c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+	err500(c, msg)
 }
 
 func requestBaseURL(r *http.Request) string {
@@ -442,7 +442,7 @@ func ApiKeyAuthMiddleware() gin.HandlerFunc {
 			apiKey = c.GetHeader("Api-Key")
 		}
 		if apiKeyEnv == "" || apiKey != apiKeyEnv {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "API key required or invalid"})
+			err401(c, "API key required or invalid")
 			return
 		}
 		c.Next()

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -47,7 +47,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			if errors.Is(err, domain.ErrIndexAlreadyExists) {
 				err409(c, "Index already exists")
 			} else {
-				err500(c, err.Error())
+				err500(c, err)
 			}
 			return
 		}
@@ -68,7 +68,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			} else if errors.Is(err, domain.ErrMissingKeyField) {
 				err400Missing(c, "Document missing key field")
 			} else {
-				err500(c, err.Error())
+				err500(c, err)
 			}
 			return
 		}
@@ -79,7 +79,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		selectFields := c.Query("$select")
 		indexes, err := app.IndexService.ListIndexes(c.Request.Context(), selectFields)
 		if err != nil {
-			err500(c, err.Error())
+			err500(c, err)
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{
@@ -95,7 +95,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			if errors.Is(err, domain.ErrIndexNotFound) {
 				err404(c, "Index not found")
 			} else {
-				err500(c, err.Error())
+				err500(c, err)
 			}
 			return
 		}
@@ -121,7 +121,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 		}
 		created, err := app.IndexService.CreateOrUpdateIndex(c.Request.Context(), indexName, io.NopCloser(bytes.NewReader(body)))
 		if err != nil {
-			err500(c, err.Error())
+			err500(c, err)
 			return
 		}
 		if created {
@@ -138,7 +138,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			if errors.Is(err, domain.ErrIndexNotFound) {
 				err404(c, "Index not found")
 			} else {
-				err500(c, err.Error())
+				err500(c, err)
 			}
 			return
 		}
@@ -152,7 +152,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			if errors.Is(err, domain.ErrIndexNotFound) {
 				err404(c, "Index not found")
 			} else {
-				err500(c, err.Error())
+				err500(c, err)
 			}
 			return
 		}
@@ -173,7 +173,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			if errors.Is(err, domain.ErrIndexNotFound) {
 				err404(c, "Index not found")
 			} else {
-				err500(c, err.Error())
+				err500(c, err)
 			}
 			return
 		}
@@ -197,7 +197,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			} else if errors.Is(err, domain.ErrDocumentNotFound) {
 				err404(c, "Document not found")
 			} else {
-				err500(c, err.Error())
+				err500(c, err)
 			}
 			return
 		}
@@ -211,7 +211,7 @@ func RegisterRoutes(r *gin.Engine, app *application.AppServices) {
 			if errors.Is(err, domain.ErrIndexNotFound) {
 				err404(c, "Index not found")
 			} else {
-				err500(c, err.Error())
+				err500(c, err)
 			}
 			return
 		}
@@ -349,7 +349,7 @@ func handleSearchError(c *gin.Context, err error) {
 		err400(c, msg)
 		return
 	}
-	err500(c, msg)
+	err500(c, err)
 }
 
 func requestBaseURL(r *http.Request) string {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -842,6 +842,86 @@ func TestSearchDocuments_GET_NoNextLinkOnLastPage(t *testing.T) {
 	}
 }
 
+// --- Structured error responses ---
+
+// errCode extracts the "code" field from an Azure-structured error body.
+func errCode(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to unmarshal error body: %v, raw=%s", err, rec.Body.String())
+	}
+	if body.Error.Code == "" {
+		t.Fatalf("error.code is empty, body=%s", rec.Body.String())
+	}
+	return body.Error.Code
+}
+
+func TestErrorFormat_400_InvalidRequest(t *testing.T) {
+	r := setupRouter(t)
+	rec := doRequest(t, r, http.MethodPost, "/indexes", "not-json")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if code := errCode(t, rec); code != "InvalidRequest" {
+		t.Errorf("error.code = %q, want InvalidRequest", code)
+	}
+}
+
+func TestErrorFormat_400_MissingRequiredProperty(t *testing.T) {
+	r := setupRouter(t)
+	doRequest(t, r, http.MethodPost, "/indexes", apiTestSchema)
+	rec := doRequest(t, r, http.MethodPost, "/indexes/movies/docs", `{"title":"no key"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if code := errCode(t, rec); code != "MissingRequiredProperty" {
+		t.Errorf("error.code = %q, want MissingRequiredProperty", code)
+	}
+}
+
+func TestErrorFormat_401_AuthenticationFailed(t *testing.T) {
+	r := setupRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/indexes", nil)
+	req.Header.Set("api-key", "wrong")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if code := errCode(t, rec); code != "AuthenticationFailed" {
+		t.Errorf("error.code = %q, want AuthenticationFailed", code)
+	}
+}
+
+func TestErrorFormat_404_ResourceNotFound(t *testing.T) {
+	r := setupRouter(t)
+	rec := doRequest(t, r, http.MethodGet, "/indexes/missing", "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if code := errCode(t, rec); code != "ResourceNotFound" {
+		t.Errorf("error.code = %q, want ResourceNotFound", code)
+	}
+}
+
+func TestErrorFormat_409_ResourceAlreadyExists(t *testing.T) {
+	r := setupRouter(t)
+	doRequest(t, r, http.MethodPost, "/indexes", apiTestSchema)
+	rec := doRequest(t, r, http.MethodPost, "/indexes", apiTestSchema)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+	if code := errCode(t, rec); code != "ResourceAlreadyExists" {
+		t.Errorf("error.code = %q, want ResourceAlreadyExists", code)
+	}
+}
+
 // Guard: ensure no DB file is left in cwd after running these tests.
 // This is a best-effort assertion — file presence is checked only if it
 // somehow gets created in the working directory.

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -922,6 +922,49 @@ func TestErrorFormat_409_ResourceAlreadyExists(t *testing.T) {
 	}
 }
 
+func TestErrorFormat_500_InternalServerError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("API_KEY", apiTestKey)
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec(apiTestSchemaSQL); err != nil {
+		_ = db.Close()
+		t.Fatalf("create schema: %v", err)
+	}
+
+	idxRepo := infrastructure.NewSQLiteIndexRepository(db)
+	docRepo := infrastructure.NewSQLiteDocumentRepository(db)
+	apps := &application.AppServices{
+		IndexService:    application.NewIndexService(idxRepo, docRepo),
+		DocumentService: application.NewDocumentService(docRepo, idxRepo),
+	}
+	r := gin.New()
+	RegisterHealthCheck(r)
+	r.Use(ApiKeyAuthMiddleware())
+	RegisterRoutes(r, apps)
+
+	// Create an index while the DB is healthy, then close it to force errors.
+	doRequest(t, r, http.MethodPost, "/indexes", apiTestSchema)
+	_ = db.Close()
+
+	rec := doRequest(t, r, http.MethodGet, "/indexes", "")
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if code := errCode(t, rec); code != "InternalServerError" {
+		t.Errorf("error.code = %q, want InternalServerError", code)
+	}
+	// Generic message must not contain internal details.
+	body := rec.Body.String()
+	if strings.Contains(body, "sql") || strings.Contains(body, "sqlite") {
+		t.Errorf("response body leaked internal details: %s", body)
+	}
+}
+
 // Guard: ensure no DB file is left in cwd after running these tests.
 // This is a best-effort assertion — file presence is checked only if it
 // somehow gets created in the working directory.


### PR DESCRIPTION
## Summary

- Adds `internal/api/errors.go` with typed helper functions (`err400`, `err400Missing`, `err401`, `err404`, `err409`, `err500`) that emit the Azure AI Search structured error format
- Replaces all flat `{"error": "..."}` responses in `handler.go` with the new helpers
- Error codes follow Azure conventions:

| HTTP | code |
|------|------|
| 400 | `InvalidRequest` |
| 400 (missing key) | `MissingRequiredProperty` |
| 401 | `AuthenticationFailed` |
| 404 | `ResourceNotFound` |
| 409 | `ResourceAlreadyExists` |
| 500 | `InternalServerError` |

## Test plan

- [ ] `TestErrorFormat_400_InvalidRequest` — invalid JSON body returns `InvalidRequest`
- [ ] `TestErrorFormat_400_MissingRequiredProperty` — missing key field returns `MissingRequiredProperty`
- [ ] `TestErrorFormat_401_AuthenticationFailed` — wrong API key returns `AuthenticationFailed`
- [ ] `TestErrorFormat_404_ResourceNotFound` — missing index returns `ResourceNotFound`
- [ ] `TestErrorFormat_409_ResourceAlreadyExists` — duplicate index returns `ResourceAlreadyExists`
- [ ] All existing tests continue to pass (`go test -race ./...`)